### PR TITLE
fix(utils): remove extra closing brace in URLSearchParams encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stiletto-web",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "license": "UNLICENSED",
   "author": "Dm94Dani",
   "description": "Web with different utilities for the game Last Oasis",

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -21,7 +21,7 @@ export const objectToURLSearchParams = (obj: object): URLSearchParams => {
     .filter((key) => obj[key as keyof typeof obj] !== undefined)
     .map(
       (key) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(obj[key as keyof typeof obj])}}`,
+        `${encodeURIComponent(key)}=${encodeURIComponent(obj[key as keyof typeof obj])}`,
     );
 
   return new URLSearchParams(keyValuePairs.join("&"));


### PR DESCRIPTION
The extra closing brace in the URL encoding was causing malformed query parameters. This fix ensures that the URLSearchParams are correctly formatted.

## Summary by Sourcery

Bug Fixes:
- Fix malformed query parameters due to an extra closing brace in URLSearchParams encoding.