### PR TITLE
refactor(trades): simplify createTrade by removing URL params and using the body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stiletto-web",
-  "version": "5.13.0",
+  "version": "5.14.0",
   "license": "UNLICENSED",
   "author": "Dm94Dani",
   "description": "Web with different utilities for the game Last Oasis",

--- a/src/functions/requests/trades.ts
+++ b/src/functions/requests/trades.ts
@@ -36,16 +36,14 @@ export const createTrade = async (
     body: JSON.stringify(requestParams),
   });
 
-  if (response) {
+  if (response?.ok) {
     return await response.json();
   }
 
   throw new Error("errors.apiConnection");
 };
 
-export const deleteTrade = async (
-  tradeId: number,
-): Promise<GenericResponse> => {
+export const deleteTrade = async (tradeId: number): Promise<boolean> => {
   const response = await fetch(
     `${config.REACT_APP_API_URL}/trades/${tradeId}`,
     {
@@ -56,8 +54,8 @@ export const deleteTrade = async (
     },
   );
 
-  if (response) {
-    return await response.json();
+  if (response.ok) {
+    return response.ok;
   }
 
   throw new Error("errors.apiConnection");

--- a/src/functions/requests/trades.ts
+++ b/src/functions/requests/trades.ts
@@ -27,13 +27,13 @@ export const getTrades = async (
 export const createTrade = async (
   requestParams: CreateTradeRequestParams,
 ): Promise<GenericResponse> => {
-  const params = objectToURLSearchParams(requestParams);
-
-  const response = await fetch(`${config.REACT_APP_API_URL}/trades?${params}`, {
+  const response = await fetch(`${config.REACT_APP_API_URL}/trades`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${getStoredItem("token")}`,
+      "Content-Type": "application/json",
     },
+    body: JSON.stringify(requestParams),
   });
 
   if (response) {


### PR DESCRIPTION
## Summary by Sourcery

Refactor the trade creation endpoint to use JSON request body instead of URL search parameters

New Features:
- Add Content-Type header to specify JSON payload when creating a trade

Enhancements:
- Modify the createTrade function to send trade data as JSON in the request body instead of URL parameters

Chores:
- Bump project version from 5.13.0 to 5.14.0