### PR TITLE
refactor(api): rename request params to request body and update reque…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stiletto-web",
-  "version": "5.14.3",
+  "version": "5.15.0",
   "license": "UNLICENSED",
   "author": "Dm94Dani",
   "description": "Web with different utilities for the game Last Oasis",

--- a/src/components/ClanMaps/ResourceMap.tsx
+++ b/src/components/ClanMaps/ResourceMap.tsx
@@ -84,10 +84,9 @@ const ResourceMap: React.FC<ResourceMapProps> = ({ map, onReturn }) => {
     lastHarvested: string,
   ) => {
     try {
-      await addResourceMap(Number(map?.mapid), {
+      await addResourceMap(Number(map?.mapid), pass ?? "", {
         x: coordinateXInput,
         y: coordinateYInput,
-        mappass: pass ?? "",
         resourcetype: resourceTypeInput,
         quality: qualityInput,
         description: descriptionInput,

--- a/src/components/ClanMaps/ResourceMapNoLog.tsx
+++ b/src/components/ClanMaps/ResourceMapNoLog.tsx
@@ -107,10 +107,9 @@ const ResourceMapNoLog: React.FC<ResourceMapNoLogProps> = (props) => {
       }
 
       try {
-        const response = await addResourceMap(mapId, {
+        const response = await addResourceMap(mapId, pass ?? "", {
           x: coordinateXInput,
           y: coordinateYInput,
-          mappass: pass ?? "",
           resourcetype: resourceTypeInput,
           quality: qualityInput,
           description: descriptionInput,

--- a/src/functions/requests/maps/index.ts
+++ b/src/functions/requests/maps/index.ts
@@ -3,7 +3,7 @@ import type { GenericResponse } from "../../../types/dto/generic";
 import type {
   AddMapRequestParams,
   AddMapResponse,
-  EditMapRequestParams,
+  EditMapRequestBody,
   MapInfo,
 } from "../../../types/dto/maps";
 import { getStoredItem } from "../../services";
@@ -69,23 +69,19 @@ export const getMap = async (
 
 export const editMap = async (
   mapId: number,
-  requestParams: EditMapRequestParams,
+  requestBody: EditMapRequestBody,
 ): Promise<GenericResponse> => {
-  const url = new URL(`${config.REACT_APP_API_URL}/maps/${mapId}`);
-  for (const key in requestParams) {
-    url.searchParams.append(
-      key,
-      String(requestParams[key as keyof EditMapRequestParams]),
-    );
-  }
-
   const headers = getStoredItem("token")
-    ? { Authorization: `Bearer ${getStoredItem("token")}` }
-    : {};
+    ? {
+        Authorization: `Bearer ${getStoredItem("token")}`,
+        "Content-Type": "application/json",
+      }
+    : { "Content-Type": "application/json" };
 
-  const response = await fetch(url, {
+  const response = await fetch(`${config.REACT_APP_API_URL}/maps/${mapId}`, {
     method: "PUT",
     headers: headers as Record<string, string>,
+    body: JSON.stringify(requestBody),
   });
 
   if (response) {

--- a/src/functions/requests/users.ts
+++ b/src/functions/requests/users.ts
@@ -3,7 +3,6 @@ import { config } from "../../config/config";
 import type { TechTreeInfo, Tree } from "../../types/dto/tech";
 import type { LoginInfo, UserInfo } from "../../types/dto/users";
 import { objectToURLSearchParams } from "../utils";
-import type { GenericResponse } from "../../types/dto/generic";
 
 export const getUser = async (): Promise<UserInfo> => {
   const response = await fetch(`${config.REACT_APP_API_URL}/users`, {

--- a/src/types/dto/maps.ts
+++ b/src/types/dto/maps.ts
@@ -22,7 +22,7 @@ export type MapJsonInfo = {
   image: string;
 };
 
-export type EditMapRequestParams = {
+export type EditMapRequestBody = {
   mapname: string;
   mapdate?: string;
   allowediting?: boolean;

--- a/src/types/dto/resources.ts
+++ b/src/types/dto/resources.ts
@@ -1,5 +1,4 @@
-export type AddResourceMapRequestParams = {
-  mappass: string;
+export type AddResourceMapRequestBody = {
   resourcetype: string;
   quality?: number;
   x: number;
@@ -15,13 +14,13 @@ export type ResourceInfo = {
   quality: number;
   x: number;
   y: number;
-  token?: string;
+  token: string;
   typemap: string;
   description?: string;
   lastharvested?: string;
 };
 
-export type EditResourceRequestParams = {
+export type EditResourceRequestBody = {
   token: string;
   description?: string;
   harvested?: string;


### PR DESCRIPTION
…st handling

Update API request types and functions to use `RequestBody` instead of `RequestParams` for consistency and clarity. Adjust request handling to use JSON payloads and proper headers for POST and PUT requests. This change improves API request structure and aligns with RESTful practices.