### PR TITLE
refactor(ClanMaps): upgrade react-leaflet to v4.2.1 and refactor map …

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-dom": "19.1.0",
     "react-helmet": "6.1.0",
     "react-i18next": "15.4.1",
-    "react-leaflet": "2.8.0",
+    "react-leaflet": "4.2.1",
     "react-router": "^7.5.0",
     "styled-components": "^6.1.16"
   },
@@ -41,7 +41,11 @@
     "lint": "biome lint --write ./src"
   },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
@@ -71,7 +75,11 @@
   },
   "packageManager": "pnpm@10.6.5",
   "pnpm": {
-    "ignoredBuiltDependencies": ["cypress"],
-    "onlyBuiltDependencies": ["cypress"]
+    "ignoredBuiltDependencies": [
+      "cypress"
+    ],
+    "onlyBuiltDependencies": [
+      "cypress"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/preset-react": "7.26.3",
     "@biomejs/biome": "1.9.4",
     "@tailwindcss/postcss": "4.1.3",
+    "@types/leaflet": "^1.9.17",
     "@types/node": "^22.14.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stiletto-web",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "license": "UNLICENSED",
   "author": "Dm94Dani",
   "description": "Web with different utilities for the game Last Oasis",
@@ -20,7 +20,6 @@
     "i18next-browser-languagedetector": "8.0.4",
     "i18next-http-backend": "3.0.2",
     "leaflet": "1.9.4",
-    "leaflet-rastercoords": "1.0.6",
     "query-string": "9.1.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -41,11 +40,7 @@
     "lint": "biome lint --write ./src"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.2%", "not dead", "not op_mini all"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
@@ -76,11 +71,7 @@
   },
   "packageManager": "pnpm@10.6.5",
   "pnpm": {
-    "ignoredBuiltDependencies": [
-      "cypress"
-    ],
-    "onlyBuiltDependencies": [
-      "cypress"
-    ]
+    "ignoredBuiltDependencies": ["cypress"],
+    "onlyBuiltDependencies": ["cypress"]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       leaflet:
         specifier: 1.9.4
         version: 1.9.4
-      leaflet-rastercoords:
-        specifier: 1.0.6
-        version: 1.0.6
       query-string:
         specifier: 9.1.1
         version: 9.1.1
@@ -1412,9 +1409,6 @@ packages:
   lazy-ass@1.6.0:
     resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
     engines: {node: '> 0.8'}
-
-  leaflet-rastercoords@1.0.6:
-    resolution: {integrity: sha512-uoGlGis7tKXdoeueCNwbfaclL38b/jztSwgWejHO+2EimxMbcQIr2PCG0E/kyJ9Z6WFkdoM2ypaypoHeitpKqg==}
 
   leaflet@1.9.4:
     resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
@@ -3433,10 +3427,6 @@ snapshots:
       verror: 1.10.0
 
   lazy-ass@1.6.0: {}
-
-  leaflet-rastercoords@1.0.6:
-    dependencies:
-      leaflet: 1.9.4
 
   leaflet@1.9.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 15.4.1
         version: 15.4.1(i18next@24.2.3(typescript@5.8.2))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-leaflet:
-        specifier: 2.8.0
-        version: 2.8.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 4.2.1
+        version: 4.2.1(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-router:
         specifier: ^7.5.0
         version: 7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -536,6 +536,13 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@react-leaflet/core@2.1.0':
+    resolution: {integrity: sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==}
+    peerDependencies:
+      leaflet: ^1.9.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@rollup/rollup-android-arm-eabi@4.37.0':
     resolution: {integrity: sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==}
@@ -1152,9 +1159,6 @@ packages:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
 
-  fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -1270,9 +1274,6 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
-
-  hoist-non-react-statics@3.3.2:
-    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
@@ -1758,12 +1759,12 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
-  react-leaflet@2.8.0:
-    resolution: {integrity: sha512-Y7oHtNrrlRH8muDttXf+jZ2Ga/X7jneSGi1GN8uEdeCfLProTqgG2Zoa5TfloS3ZnY20v7w+DIenMG59beFsQw==}
+  react-leaflet@4.2.1:
+    resolution: {integrity: sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==}
     peerDependencies:
-      leaflet: ^1.6.0
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0  || ^17.0.0
+      leaflet: ^1.9.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -2112,9 +2113,6 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
-
-  warning@4.0.3:
-    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -2573,6 +2571,12 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@react-leaflet/core@2.1.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      leaflet: 1.9.4
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   '@rollup/rollup-android-arm-eabi@4.37.0':
     optional: true
 
@@ -2744,7 +2748,7 @@ snapshots:
 
   '@types/react-leaflet@3.0.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      react-leaflet: 2.8.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-leaflet: 4.2.1(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - leaflet
       - react
@@ -3180,8 +3184,6 @@ snapshots:
 
   extsprintf@1.3.0: {}
 
-  fast-deep-equal@3.1.3: {}
-
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3310,10 +3312,6 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-
-  hoist-non-react-statics@3.3.2:
-    dependencies:
-      react-is: 16.13.1
 
   html-parse-stringify@3.0.1:
     dependencies:
@@ -3723,15 +3721,12 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-leaflet@2.8.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-leaflet@4.2.1(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.26.10
-      fast-deep-equal: 3.1.3
-      hoist-non-react-statics: 3.3.2
+      '@react-leaflet/core': 2.1.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       leaflet: 1.9.4
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      warning: 4.0.3
 
   react-refresh@0.14.2: {}
 
@@ -4086,10 +4081,6 @@ snapshots:
       yaml: 2.7.0
 
   void-elements@3.1.0: {}
-
-  warning@4.0.3:
-    dependencies:
-      loose-envify: 1.4.0
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: 4.1.3
         version: 4.1.3
+      '@types/leaflet':
+        specifier: ^1.9.17
+        version: 1.9.17
       '@types/node':
         specifier: ^22.14.0
         version: 22.14.0
@@ -747,8 +750,14 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/history@4.7.11':
     resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
+
+  '@types/leaflet@1.9.17':
+    resolution: {integrity: sha512-IJ4K6t7I3Fh5qXbQ1uwL3CFVbCi6haW9+53oLWgdKlLP7EaS21byWFJxxqOx9y8I0AP0actXSJLVMbyvxhkUTA==}
 
   '@types/node@22.14.0':
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
@@ -2732,7 +2741,13 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/history@4.7.11': {}
+
+  '@types/leaflet@1.9.17':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/node@22.14.0':
     dependencies:

--- a/src/components/ClanMaps/MapExtended.tsx
+++ b/src/components/ClanMaps/MapExtended.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useRef, forwardRef } from "react";
+import type React from "react";
+import { useEffect, useRef, forwardRef } from "react";
 import L from "leaflet";
 import { MapContainer, useMap } from "react-leaflet";
 import type { MapContainerProps } from "react-leaflet";
 
 // Import our custom RasterCoords implementation
-// This replaces the outdated leaflet-rastercoords library
 import { createRasterCoords } from "./RasterCoordsUtil";
 
 // This component initializes the RasterCoords functionality after the map is loaded

--- a/src/components/ClanMaps/MapExtended.tsx
+++ b/src/components/ClanMaps/MapExtended.tsx
@@ -38,6 +38,9 @@ const RasterCoordsInitializer: React.FC<RasterCoordsInitializerProps> = ({
         2,
       );
       initializedRef.current = true;
+    } else if (center) {
+      // If center changes after initialization, update the view
+      map.setView(new L.LatLng(center[0], center[1]), map.getZoom());
     }
 
     // Store the rasterCoords instance on the map for potential external access

--- a/src/components/ClanMaps/MapLayer.tsx
+++ b/src/components/ClanMaps/MapLayer.tsx
@@ -213,20 +213,6 @@ const MapLayer: React.FC<MapLayerProps> = ({
     return null;
   };
 
-  // Keep the old handler for reference but it's no longer used directly
-  const handleClick = useCallback(
-    (e: { latlng: { lat: number; lng: number } }) => {
-      const roundedLat = Math.round(e.latlng.lat * 100) / 100;
-      const roundedLng = Math.round(e.latlng.lng * 100) / 100;
-
-      setHasLocation(true);
-      setCoordinateXInput(roundedLat);
-      setCoordinateYInput(roundedLng);
-      changeInput?.(roundedLat, roundedLng);
-    },
-    [changeInput],
-  );
-
   const handleShowGrid = useCallback(() => setGridOpacity(1), []);
   const handleHideGrid = useCallback(() => setGridOpacity(0), []);
 

--- a/src/components/ClanMaps/MapLayer.tsx
+++ b/src/components/ClanMaps/MapLayer.tsx
@@ -6,7 +6,7 @@ import {
   Tooltip,
   ImageOverlay,
   Circle,
-  // @ts-expect-error Temporarily ignore type checking for react-leaflet until types are installed
+  useMapEvents,
 } from "react-leaflet";
 import { useTranslation } from "react-i18next";
 import L from "leaflet";
@@ -197,6 +197,23 @@ const MapLayer: React.FC<MapLayerProps> = ({
     t,
   ]);
 
+  // Map click handler component using useMapEvents hook
+  const MapClickHandler = () => {
+    useMapEvents({
+      click: (e) => {
+        const roundedLat = Math.round(e.latlng.lat * 100) / 100;
+        const roundedLng = Math.round(e.latlng.lng * 100) / 100;
+
+        setHasLocation(true);
+        setCoordinateXInput(roundedLat);
+        setCoordinateYInput(roundedLng);
+        changeInput?.(roundedLat, roundedLng);
+      },
+    });
+    return null;
+  };
+
+  // Keep the old handler for reference but it's no longer used directly
   const handleClick = useCallback(
     (e: { latlng: { lat: number; lng: number } }) => {
       const roundedLat = Math.round(e.latlng.lat * 100) / 100;
@@ -263,10 +280,10 @@ const MapLayer: React.FC<MapLayerProps> = ({
       <MapExtended
         maxZoom={6}
         style={{ width: "100%", height: "calc(100vh - 200px)" }}
-        onClick={handleClick}
         center={center}
         attributionControl={false}
       >
+        <MapClickHandler />
         <ImageOverlay
           bounds={[
             [85.5, -180],

--- a/src/components/ClanMaps/RasterCoordsUtil.ts
+++ b/src/components/ClanMaps/RasterCoordsUtil.ts
@@ -1,0 +1,79 @@
+/**
+ * Custom implementation of leaflet-rastercoords functionality
+ * This provides the same functionality as the original library but works with the latest Leaflet version
+ */
+import L from "leaflet";
+
+/**
+ * RasterCoords class for handling image coordinate transformations
+ */
+export interface RasterCoordsType {
+  unproject: (point: [number, number]) => L.LatLng;
+  project: (point: [number, number]) => L.Point;
+  zoomLevel: () => number;
+  getMaxBounds: () => L.LatLngBounds;
+  setMaxBounds: () => void;
+}
+
+/**
+ * Create a RasterCoords instance that provides the same functionality as the original library
+ * @param map - Leaflet map instance
+ * @param imgsize - Image dimensions [width, height]
+ * @param tilesize - Tile size in pixels (default: 256)
+ * @param setMaxBounds - Whether to automatically set map max bounds (default: true)
+ * @returns RasterCoords instance
+ */
+export function createRasterCoords(
+  map: L.Map,
+  imgsize: [number, number],
+  tilesize = 256,
+  shouldSetMaxBounds = true,
+): RasterCoordsType {
+  const width = imgsize[0];
+  const height = imgsize[1];
+
+  // Calculate the appropriate zoom level for the image
+  const zoomLevel = (): number => {
+    return Math.ceil(
+      Math.log(Math.max(width, height) / tilesize) / Math.log(2),
+    );
+  };
+
+  const zoom = zoomLevel();
+
+  // Unproject coordinates from image space to map space
+  const unproject = (coords: [number, number]): L.LatLng => {
+    return map.unproject(coords, zoom);
+  };
+
+  // Project coordinates from map space to image space
+  const project = (coords: L.LatLngExpression): L.Point => {
+    return map.project(coords, zoom);
+  };
+
+  // Get the maximum bounds of the image
+  const getMaxBounds = (): L.LatLngBounds => {
+    const southWest = unproject([0, height]);
+    const northEast = unproject([width, 0]);
+    return new L.LatLngBounds(southWest, northEast);
+  };
+
+  // Set the maximum bounds on the map
+  const setMaxBounds = (): void => {
+    const bounds = getMaxBounds();
+    map.setMaxBounds(bounds);
+  };
+
+  // Automatically set max bounds if requested
+  if (shouldSetMaxBounds && width && height) {
+    setMaxBounds();
+  }
+
+  return {
+    unproject,
+    project,
+    zoomLevel,
+    getMaxBounds,
+    setMaxBounds,
+  };
+}


### PR DESCRIPTION
…components

Upgrade react-leaflet from v2.8.0 to v4.2.1 to leverage the latest features and improvements. Refactor MapLayer and MapExtended components to use the new react-leaflet hooks and APIs. Replace the deprecated leaflet-rastercoords library with a custom implementation in RasterCoordsUtil.ts for better compatibility and maintainability. Update package.json and pnpm-lock.yaml to reflect the dependency changes.

## Summary by Sourcery

Upgrade react-leaflet to v4.2.1 and refactor map components to use modern React hooks and custom RasterCoords implementation

New Features:
- Implemented a custom RasterCoordsInitializer component to handle map coordinate transformations

Enhancements:
- Refactored MapExtended and MapLayer components to use react-leaflet hooks and modern component patterns
- Replaced deprecated leaflet-rastercoords library with a custom implementation in RasterCoordsUtil.ts

Chores:
- Updated package dependencies to react-leaflet v4.2.1
- Removed leaflet-rastercoords dependency
- Added @types/leaflet type definitions