### PR TITLE
refactor(ClanMaps): extract ResourcePopup component from MapLayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stiletto-web",
-  "version": "5.25.3",
+  "version": "5.26.0",
   "license": "UNLICENSED",
   "author": "Dm94Dani",
   "description": "Web with different utilities for the game Last Oasis",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -347,5 +347,7 @@
   "creature.experience": "Experience",
   "creature.tier": "Tier",
   "creature.health": "Health",
-  "creature.info": "Info"
+  "creature.info": "Info",
+  "common.noData": "No data",
+  "map.range": "Range"
 }

--- a/src/components/ClanMaps/ResourcePopup.tsx
+++ b/src/components/ClanMaps/ResourcePopup.tsx
@@ -1,0 +1,158 @@
+import type React from "react";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import Icon from "../Icon";
+import type { ResourceInfo } from "@ctypes/dto/resources";
+
+interface ResourcePopupProps {
+  resource: ResourceInfo;
+  poachingHutRadius: number;
+  updateResource?: (
+    mapId: number,
+    resourceId: number,
+    token: string,
+    date: string,
+  ) => void;
+  deleteResource?: (resourceId: number, resourceToken: string) => void;
+  setPoachingHutRadius: (radius: number) => void;
+}
+
+const ResourcePopup: React.FC<ResourcePopupProps> = ({
+  resource,
+  poachingHutRadius,
+  updateResource,
+  deleteResource,
+  setPoachingHutRadius,
+}) => {
+  const { t } = useTranslation();
+
+  const handleDeleteResource = useCallback(() => {
+    deleteResource?.(resource.resourceid, resource?.token ?? "");
+  }, [deleteResource, resource]);
+
+  const handlePoachingRadiusChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setPoachingHutRadius(Number(e.target.value));
+    },
+    [setPoachingHutRadius],
+  );
+
+  const getResourceEstimatedQuality = useCallback(() => {
+    const quality = 4;
+    const diff = Math.abs(
+      new Date().getTime() - new Date(resource.lastharvested ?? "").getTime(),
+    );
+    const minutes = Math.floor(diff / 1000 / 60);
+    const estimatedQuality = (minutes - 45) / 10;
+    const remainingQuality = quality - estimatedQuality;
+
+    const now = new Date();
+    const date = `${now.getFullYear()}-${
+      now.getMonth() + 1
+    }-${now.getDate()} ${now.getHours()}:${now.getMinutes()}`;
+    const fullDate = new Date(now.getTime() + remainingQuality * 10 * 60000);
+
+    return (
+      <div className="resource-quality-info bg-gray-800/30 p-3 rounded-md shadow-inner">
+        <button
+          type="button"
+          className="w-full p-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 mb-3 font-medium transition-all duration-200 transform hover:translate-y-[-1px] shadow-md"
+          onClick={() =>
+            updateResource?.(
+              resource.mapid,
+              resource.resourceid,
+              resource.token ?? "",
+              date,
+            )
+          }
+        >
+          {t("resources.harvestedNow")}
+        </button>
+        <div className="mb-2 text-gray-300 flex justify-between items-center">
+          <span>{t("resources.lastHarvested")}:</span>{" "}
+          <span className="font-medium">{resource.lastharvested}</span>
+        </div>
+        <div className="mb-2 text-gray-300 flex justify-between items-center">
+          <span>{t("Spawns in")}:</span>
+          <span className="font-medium text-green-400">
+            {remainingQuality > 0
+              ? `${Math.max(0, remainingQuality * 10)} ${t("common.minutes")}`
+              : t("common.now")}
+          </span>
+        </div>
+        <div className="mb-2 text-gray-300 flex justify-between items-center">
+          <span>{t("Date")}:</span>{" "}
+          <span className="font-medium">{fullDate.toLocaleString()}</span>
+        </div>
+      </div>
+    );
+  }, [resource, t, updateResource]);
+
+  const isPoachingHut =
+    resource.resourcetype === "Poaching Hut" ||
+    resource.resourcetype === "Enemy Poaching Hut";
+
+  return (
+    <div className="resource-popup p-4 bg-gray-900 rounded-lg shadow-lg border border-gray-700 max-w-sm">
+      <div className="resource-header flex items-center gap-3 mb-3 pb-3 border-b border-gray-600">
+        <Icon name={resource.resourcetype} />
+        <span className="text-xl font-semibold text-white">
+          {t(resource.resourcetype)}
+        </span>
+      </div>
+
+      <div className="resource-coordinates mb-3 px-3 py-1.5 bg-gray-800 rounded-md text-gray-300 inline-block text-sm font-mono shadow-inner">
+        [{`${Math.floor(resource.x)},${Math.floor(resource.y)}`}]
+      </div>
+
+      {resource.description && (
+        <div className="resource-description mb-4 p-2 bg-gray-800/50 rounded-md text-gray-200 italic border-l-2 border-blue-500">
+          {resource.description}
+        </div>
+      )}
+
+      {resource.lastharvested && (
+        <div className="resource-harvest-info mb-3">
+          {getResourceEstimatedQuality()}
+        </div>
+      )}
+
+      <div className="resource-actions flex flex-col gap-2">
+        {resource.token && (
+          <button
+            type="button"
+            className="w-full p-2.5 bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 transition-all duration-200 transform hover:translate-y-[-1px] font-medium shadow-md"
+            onClick={handleDeleteResource}
+            aria-label={`${t("common.delete")} ${t(resource.resourcetype)} ${t("common.at")} ${Math.floor(resource.x)},${Math.floor(resource.y)}`}
+          >
+            {t("common.delete")}
+          </button>
+        )}
+
+        {isPoachingHut && (
+          <div className="poaching-radius-control border-t border-yellow-500/70 mt-3 pt-3 bg-gray-800/30 p-3 rounded-md shadow-inner">
+            <div className="flex justify-between mb-2">
+              <span className="text-sm font-medium text-gray-300">
+                {t("Range")}:
+              </span>
+              <span className="text-sm font-bold text-yellow-400">
+                {poachingHutRadius * 100}m
+              </span>
+            </div>
+            <input
+              className="w-full accent-blue-500 h-2 rounded-lg appearance-none cursor-pointer bg-gray-700 mt-1"
+              id="formPoachingRadius"
+              value={poachingHutRadius}
+              onChange={handlePoachingRadiusChange}
+              type="range"
+              min="0"
+              max="250"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ResourcePopup;

--- a/src/components/ClanMaps/ResourcePopup.tsx
+++ b/src/components/ClanMaps/ResourcePopup.tsx
@@ -50,7 +50,6 @@ const ResourcePopup: React.FC<ResourcePopupProps> = ({
     const date = `${now.getFullYear()}-${
       now.getMonth() + 1
     }-${now.getDate()} ${now.getHours()}:${now.getMinutes()}`;
-    const fullDate = new Date(now.getTime() + remainingQuality * 10 * 60000);
 
     return (
       <div className="resource-quality-info bg-gray-800/30 p-3 rounded-md shadow-inner">
@@ -79,10 +78,6 @@ const ResourcePopup: React.FC<ResourcePopupProps> = ({
               ? `${Math.max(0, remainingQuality * 10)} ${t("common.minutes")}`
               : t("common.now")}
           </span>
-        </div>
-        <div className="mb-2 text-gray-300 flex justify-between items-center">
-          <span>{t("Date")}:</span>{" "}
-          <span className="font-medium">{fullDate.toLocaleString()}</span>
         </div>
       </div>
     );
@@ -133,7 +128,7 @@ const ResourcePopup: React.FC<ResourcePopupProps> = ({
           <div className="poaching-radius-control border-t border-yellow-500/70 mt-3 pt-3 bg-gray-800/30 p-3 rounded-md shadow-inner">
             <div className="flex justify-between mb-2">
               <span className="text-sm font-medium text-gray-300">
-                {t("Range")}:
+                {t("map.range")}:
               </span>
               <span className="text-sm font-bold text-yellow-400">
                 {poachingHutRadius * 100}m

--- a/src/components/ClanMaps/ResourcePopup.tsx
+++ b/src/components/ClanMaps/ResourcePopup.tsx
@@ -51,6 +51,9 @@ const ResourcePopup: React.FC<ResourcePopupProps> = ({
       now.getMonth() + 1
     }-${now.getDate()} ${now.getHours()}:${now.getMinutes()}`;
 
+    const lastHarvestedDate = new Date(resource.lastharvested ?? "");
+    const lastHarvestedDateFormatted = `${lastHarvestedDate.toLocaleDateString()} ${lastHarvestedDate.toLocaleTimeString()}`;
+
     return (
       <div className="resource-quality-info bg-gray-800/30 p-3 rounded-md shadow-inner">
         <button
@@ -69,7 +72,7 @@ const ResourcePopup: React.FC<ResourcePopupProps> = ({
         </button>
         <div className="mb-2 text-gray-300 flex justify-between items-center">
           <span>{t("resources.lastHarvested")}:</span>{" "}
-          <span className="font-medium">{resource.lastharvested}</span>
+          <span className="font-medium">{lastHarvestedDateFormatted}</span>
         </div>
         <div className="mb-2 text-gray-300 flex justify-between items-center">
           <span>{t("Spawns in")}:</span>


### PR DESCRIPTION
Extracted the resource popup logic into a separate ResourcePopup component to improve code maintainability and reduce redundancy in MapLayer. This change centralizes the resource popup rendering logic and makes it reusable.

## Summary by Sourcery

Extract the resource marker popup logic from the MapLayer component into a new, reusable ResourcePopup component.

Enhancements:
- Refactor `MapLayer` by moving resource popup rendering and associated logic (quality estimation, deletion, radius control) to the dedicated `ResourcePopup` component.
- Improve the styling and layout of the resource popup.