### PR TITLE
feat(Menu): add closeMenu function to hide menu on mobile navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stiletto-web",
-  "version": "5.26.0",
+  "version": "5.26.1",
   "license": "UNLICENSED",
   "author": "Dm94Dani",
   "description": "Web with different utilities for the game Last Oasis",

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -22,6 +22,13 @@ const Menu: React.FC<MenuProps> = ({
   const { t } = useTranslation();
   const { isConnected } = useUser();
 
+  const closeMenu = (): void => {
+    const menu = document.getElementById("navbar-main-menu");
+    if (menu && !menu.classList.contains("hidden") && window.innerWidth < 768) {
+      menu.classList.add("hidden");
+    }
+  };
+
   const getLanguageFlag = (lng?: string): string => {
     if (!lng) {
       return "/img/en.jpg";
@@ -49,7 +56,11 @@ const Menu: React.FC<MenuProps> = ({
     <header className="bg-gray-800">
       <div className="container mx-auto px-4">
         <div className="flex flex-wrap md:flex-nowrap items-center justify-between py-2">
-          <Link to="/" className="flex items-center space-x-2 text-white">
+          <Link
+            to="/"
+            className="flex items-center space-x-2 text-white"
+            onClick={closeMenu}
+          >
             <span className="text-2xl font-medium web-title">Stiletto</span>
             <img
               width="35"
@@ -98,6 +109,7 @@ const Menu: React.FC<MenuProps> = ({
                 <Link
                   to="/crafter"
                   className="block py-2 text-white hover:text-gray-300"
+                  onClick={closeMenu}
                 >
                   {t("menu.crafting")}
                 </Link>
@@ -106,6 +118,7 @@ const Menu: React.FC<MenuProps> = ({
                 <Link
                   to={isConnected ? "/maps" : "/map"}
                   className="block py-2 text-white hover:text-gray-300"
+                  onClick={closeMenu}
                 >
                   {t("menu.resourceMaps")}
                 </Link>
@@ -114,6 +127,7 @@ const Menu: React.FC<MenuProps> = ({
                 <Link
                   to="/clanlist"
                   className="block py-2 text-white hover:text-gray-300"
+                  onClick={closeMenu}
                 >
                   {t("menu.clanList")}
                 </Link>
@@ -122,6 +136,7 @@ const Menu: React.FC<MenuProps> = ({
                 <Link
                   to="/trades"
                   className="block py-2 text-white hover:text-gray-300"
+                  onClick={closeMenu}
                 >
                   {t("menu.trades")}
                 </Link>
@@ -130,6 +145,7 @@ const Menu: React.FC<MenuProps> = ({
                 <Link
                   to="/wiki"
                   className="block py-2 text-white hover:text-gray-300"
+                  onClick={closeMenu}
                 >
                   {t("menu.wiki")}
                 </Link>
@@ -138,6 +154,7 @@ const Menu: React.FC<MenuProps> = ({
                 <Link
                   to="/tech"
                   className="block py-2 text-white hover:text-gray-300"
+                  onClick={closeMenu}
                 >
                   {t("menu.techTree")}
                 </Link>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useState, type KeyboardEvent } from "react";
+import { useState, useRef, type KeyboardEvent } from "react";
 import { Link } from "react-router";
 import DiscordButton from "./DiscordButton";
 import { useTranslation } from "react-i18next";
@@ -21,11 +21,15 @@ const Menu: React.FC<MenuProps> = ({
   const [searchText, setSearchText] = useState<string>("");
   const { t } = useTranslation();
   const { isConnected } = useUser();
+  const menuRef = useRef<HTMLDivElement>(null);
 
   const closeMenu = (): void => {
-    const menu = document.getElementById("navbar-main-menu");
-    if (menu && !menu.classList.contains("hidden") && window.innerWidth < 768) {
-      menu.classList.add("hidden");
+    if (
+      menuRef.current &&
+      !menuRef.current.classList.contains("hidden") &&
+      window.innerWidth < 768
+    ) {
+      menuRef.current.classList.add("hidden");
     }
   };
 
@@ -76,8 +80,7 @@ const Menu: React.FC<MenuProps> = ({
             className="md:hidden p-2 text-white hover:bg-gray-700 rounded-lg"
             type="button"
             onClick={() => {
-              const menu = document.getElementById("navbar-main-menu");
-              menu?.classList.toggle("hidden");
+              menuRef.current?.classList.toggle("hidden");
             }}
             aria-label="Toggle Menu"
           >
@@ -101,7 +104,7 @@ const Menu: React.FC<MenuProps> = ({
 
           {/* Navigation menu */}
           <div
-            id="navbar-main-menu"
+            ref={menuRef}
             className="hidden md:flex md:items-center w-full md:justify-around"
           >
             <ul className="flex flex-col md:flex-row md:space-x-4 mt-4 md:mt-0">


### PR DESCRIPTION
The closeMenu function ensures the main menu is hidden when a link is clicked on mobile devices (window width < 768px). This improves user experience by automatically closing the menu after navigation, avoiding manual closure.

## Summary by Sourcery

Add functionality to automatically close the mobile navigation menu upon link selection.

Enhancements:
- Automatically hide the main navigation menu when a link is clicked on mobile devices (screen width < 768px).

Chores:
- Bump package version.