### PR TITLE
feat(TechTree): add level and points cost fields to TechItem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stiletto-web",
-  "version": "5.27.1",
+  "version": "5.28.0",
   "license": "UNLICENSED",
   "author": "Dm94Dani",
   "description": "Web with different utilities for the game Last Oasis",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -257,6 +257,8 @@
   "techTree.noOneHasLearnedIt": "No one has learnt it",
   "techTree.needClanForFunction": "You need a clan for this function",
   "techTree.toggleLearned": "Toggle learned",
+  "techTree.level": "Level",
+  "techTree.pointsCost": "Points Cost",
   "common.privacyPolicy": "Privacy Policy",
   "walkers.searchWalkers": "Search Walkers",
   "common.yes": "Yes",

--- a/src/components/TechTree/CustomSkillTree.tsx
+++ b/src/components/TechTree/CustomSkillTree.tsx
@@ -4,9 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { TechItem } from "@ctypes/item";
 import type { Tree } from "@ctypes/dto/tech";
 import type { SkillStateMap } from "@ctypes/Skill";
-import { getItemUrl } from "@functions/utils";
 import Icon from "../Icon";
-import SkillNodeBtn from "./SkillNodeBtn";
 
 interface NodeData {
   id: string;
@@ -348,7 +346,6 @@ const CustomSkillTree: React.FC<{
   treeId: Tree;
   title: string;
   items: TechItem[];
-  clan?: number;
 }> = ({ theme, treeId, title, items }) => {
   const { t } = useTranslation();
 

--- a/src/components/TechTree/CustomSkillTree.tsx
+++ b/src/components/TechTree/CustomSkillTree.tsx
@@ -349,7 +349,7 @@ const CustomSkillTree: React.FC<{
   title: string;
   items: TechItem[];
   clan?: number;
-}> = ({ theme, treeId, title, items, clan }) => {
+}> = ({ theme, treeId, title, items }) => {
   const { t } = useTranslation();
 
   // Function to build the tree structure
@@ -358,7 +358,6 @@ const CustomSkillTree: React.FC<{
       const childrens: Array<{
         id: string;
         title: string;
-        tooltip: { content: React.ReactNode };
         children: any[];
         item: TechItem;
       }> = [];
@@ -368,7 +367,6 @@ const CustomSkillTree: React.FC<{
         const item = {
           id: i.name,
           title: t(i.name),
-          tooltip: { content: getContentItem(i) },
           children: getChildrens(i.name),
           item: i,
         };
@@ -378,41 +376,6 @@ const CustomSkillTree: React.FC<{
       return childrens;
     },
     [items, t],
-  );
-
-  // Function to generate tooltip content
-  const getContentItem = useCallback(
-    (item: TechItem): React.ReactNode => {
-      return (
-        <div className="mx-auto">
-          <div className="text-center mb-1">
-            <a
-              href={getItemUrl(item.name)}
-              target="_blank"
-              rel="noopener noreferrer"
-              title={t("menu.wiki")}
-            >
-              <Icon key={item.name} name={item.name} width={35} />
-              {t("menu.wiki")}
-            </a>
-          </div>
-          <p className="text-center border-b border-warning">
-            {t("crafting.whoHasLearnedIt")}
-          </p>
-          {clan ? (
-            <SkillNodeBtn
-              key={`btn-${item.name}`}
-              item={item}
-              clan={clan}
-              tree={treeId}
-            />
-          ) : (
-            t("techTree.needClanForFunction")
-          )}
-        </div>
-      );
-    },
-    [clan, t, treeId],
   );
 
   // Function to save skills to storage

--- a/src/components/TechTree/ModernSkillTree.tsx
+++ b/src/components/TechTree/ModernSkillTree.tsx
@@ -246,6 +246,20 @@ const ModernSkillTree: React.FC<ModernSkillTreeProps> = ({
               {node.id}
             </a>
           </div>
+          <div className="text-center mb-2">
+            {node.item?.level && (
+              <p className="text-sm text-sandLight mb-1">
+                <span className="font-bold">{t("techTree.level")}: </span>
+                {node.item.level}
+              </p>
+            )}
+            {node.item?.pointsCost && (
+              <p className="text-sm text-sandLight mb-1">
+                <span className="font-bold">{t("techTree.pointsCost")}: </span>
+                {node.item.pointsCost}
+              </p>
+            )}
+          </div>
           {canLearn && (
             <button
               type="button"

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -70,6 +70,9 @@ export type TechItem = {
   name: string;
   parent: string;
   unlocks?: string[];
+  level?: number;
+  pointsCost?: number;
+  onlyDevs?: boolean;
 };
 
 export type ItemCompleteInfo = {


### PR DESCRIPTION
This commit introduces new fields (`level`, `pointsCost`, and `onlyDevs`) to the `TechItem` type and displays them in the skill tree UI. Additionally, it removes unused tooltip logic from the `CustomSkillTree` component to simplify the codebase.

## Summary by Sourcery

Introduce level and points cost for tech items and simplify skill tree components.

New Features:
- Add `level`, `pointsCost`, and `onlyDevs` fields to the `TechItem` type.
- Display `level` and `pointsCost` in the `ModernSkillTree` component if available.

Enhancements:
- Remove unused tooltip generation logic from the `CustomSkillTree` component.
- Remove the unused `clan` prop from the `CustomSkillTree` component.