### PR TITLE
feat(translation): add "produces" label to crafting output

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -44,6 +44,7 @@
   "common.analyticsCookiesDescription": "These cookies help us understand how visitors interact with the website, and help us improve our services.",
   "common.functionality": "Functionality",
   "common.functionalityCookiesDescription": "These cookies enable the website to provide enhanced functionality and personalization.",
+  "common.produces": "Produces",
   "auth.loginWithDiscord": "Login with discord",
   "auth.connectDemo": "Connect in demo mode",
   "crafting.calculator": "Crafter",

--- a/src/components/Ingredients.tsx
+++ b/src/components/Ingredients.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { memo } from "react";
 import Ingredient from "./Ingredient";
+import { useTranslation } from "react-i18next";
 import type { Ingredient as IngredientType } from "@ctypes";
 import type { ItemRecipe } from "@ctypes/item";
 
@@ -10,12 +11,24 @@ interface IngredientsProps {
 }
 
 const Ingredients: React.FC<IngredientsProps> = memo(({ crafting, value }) => {
+  const { t } = useTranslation();
+
   if (!crafting?.ingredients) {
     return null;
   }
 
+  const outputAmount =
+    crafting.output && crafting.output > 1 ? crafting.output : null;
+
   return (
     <div className="w-full grid grid-cols-1 gap-3">
+      {outputAmount && (
+        <div className="bg-gray-700 rounded-lg p-2 mb-1 text-center">
+          <span className="text-yellow-400 font-medium">
+            {t("common.produces")}: {outputAmount}
+          </span>
+        </div>
+      )}
       {crafting.ingredients.map((ingredient) => (
         <div
           key={ingredient.name}


### PR DESCRIPTION
Add a new translation key "common.produces" to display the output amount in the crafting ingredients component. This enhances user experience by clearly indicating the quantity of items produced.