### PR TITLE
feat(item): add rarity parameter to item URLs and update rarity enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stiletto-web",
-  "version": "5.32.1",
+  "version": "5.33.0",
   "license": "UNLICENSED",
   "author": "Dm94Dani",
   "description": "Web with different utilities for the game Last Oasis",

--- a/src/components/HeaderMeta.tsx
+++ b/src/components/HeaderMeta.tsx
@@ -4,14 +4,14 @@ import { Helmet } from "react-helmet";
 interface HeaderMetaProps {
   title: string;
   description: string;
-  cannonical: string;
+  canonical: string;
   children?: React.ReactNode;
 }
 
 const HeaderMeta: React.FC<HeaderMetaProps> = ({
   title,
   description,
-  cannonical,
+  canonical,
   children,
 }) => {
   return (
@@ -21,7 +21,7 @@ const HeaderMeta: React.FC<HeaderMetaProps> = ({
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
-      <link rel="canonical" href={cannonical} />
+      <link rel="canonical" href={canonical} />
       {children}
     </Helmet>
   );

--- a/src/components/TechTree/ModernSkillTree.tsx
+++ b/src/components/TechTree/ModernSkillTree.tsx
@@ -186,7 +186,7 @@ const ModernSkillTree: React.FC<ModernSkillTreeProps> = ({
       // Check if parent node is selected
       return skills[node.parentId]?.nodeState === "selected";
     },
-    [nodes, skills]
+    [nodes, skills],
   );
 
   const toggleNode = useCallback(
@@ -214,7 +214,7 @@ const ModernSkillTree: React.FC<ModernSkillTreeProps> = ({
         return newSkills;
       });
     },
-    [treeId, nodes]
+    [treeId, nodes],
   );
 
   const showTooltip = useCallback((nodeId: string) => {
@@ -285,7 +285,7 @@ const ModernSkillTree: React.FC<ModernSkillTreeProps> = ({
         </div>
       );
     },
-    [clan, nodes, t, treeId, toggleNode, canLearnNode]
+    [clan, nodes, t, treeId, toggleNode, canLearnNode],
   );
 
   // Zoom controls
@@ -320,7 +320,7 @@ const ModernSkillTree: React.FC<ModernSkillTreeProps> = ({
       setPosition((prev) => ({ x: prev.x + dx, y: prev.y + dy }));
       setDragStart({ x: e.clientX, y: e.clientY });
     },
-    [isDragging, dragStart]
+    [isDragging, dragStart],
   );
 
   const handleMouseUp = useCallback(() => {

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -1,5 +1,6 @@
 import { config } from "@config/config";
 import { supportedLanguages } from "@config/languages";
+import type { Rarity } from "@ctypes/item";
 
 export const getDomain = () =>
   window.location.protocol.concat("//").concat(window.location.hostname) +
@@ -11,19 +12,18 @@ export const getItemCodedName = (itemName: string) =>
 export const getItemDecodedName = (itemName: string) =>
   decodeURI(String(itemName)).replaceAll("_", " ").toLowerCase().trim();
 
-/**
- * Obtiene el prefijo de idioma válido para las URLs
- * @returns El prefijo de idioma con la barra inicial si es válido, o cadena vacía
- */
 const getValidLangPrefix = (): string => {
-  const currentLang = window.location.pathname.split('/').filter(Boolean)[0];
+  const currentLang = window.location.pathname.split("/").filter(Boolean)[0];
   const supportedLangCodes = supportedLanguages.map((lang) => lang.key);
-  return supportedLangCodes.includes(currentLang) && currentLang ? `/${currentLang}` : '';
+  return supportedLangCodes.includes(currentLang) && currentLang
+    ? `/${currentLang}`
+    : "";
 };
 
-export const getItemUrl = (itemName: string) => {
+export const getItemUrl = (itemName: string, rarity?: Rarity) => {
   const langPrefix = getValidLangPrefix();
-  return `${langPrefix}/item/${encodeURI(getItemCodedName(itemName))}`;
+  const rarityPath = rarity ? `/${rarity}` : "";
+  return `${langPrefix}/item/${encodeURI(getItemCodedName(itemName))}${rarityPath}`;
 };
 
 export const getCreatureUrl = (creatureName: string) => {

--- a/src/pages/CreatureWiki.tsx
+++ b/src/pages/CreatureWiki.tsx
@@ -117,7 +117,7 @@ const CreatureWiki = () => {
       <HeaderMeta
         title={`${creatureName} - Stiletto for Last Oasis`}
         description={`All information for ${creatureName}`}
-        cannonical={getCreatureUrl(creatureName)}
+        canonical={getCreatureUrl(creatureName)}
       />
       <div className="flex flex-wrap -mx-4">
         <div className="w-full md:w-1/2 px-4">

--- a/src/pages/ItemWiki.tsx
+++ b/src/pages/ItemWiki.tsx
@@ -53,7 +53,9 @@ const ItemWiki = () => {
   const [allItems, setAllItems] = useState<Item[]>([]);
   const [textColor, setTextColor] = useState<string>("text-gray-400");
 
-  const rarity = (rarityParam as Rarity) ?? Rarity.Common;
+  const rarity = Object.values(Rarity).includes(rarityParam as Rarity)
+    ? (rarityParam as Rarity)
+    : Rarity.Common;
 
   useEffect(() => {
     const loadData = async () => {

--- a/src/pages/ItemWiki.tsx
+++ b/src/pages/ItemWiki.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { getItems, getItemInfo } from "@functions/github";
-import { Navigate, useParams } from "react-router";
+import { Navigate, useParams, useNavigate } from "react-router";
 import Ingredients from "@components/Ingredients";
 import Station from "@components/Station";
 import Icon from "@components/Icon";
@@ -27,31 +27,33 @@ import HeaderMeta from "@components/HeaderMeta";
 import { type Item, type ItemCompleteInfo, Rarity } from "@ctypes/item";
 
 const WikiDescription = React.lazy(
-  () => import("@components/Wiki/WikiDescription")
+  () => import("@components/Wiki/WikiDescription"),
 );
 const SchematicDropInfo = React.lazy(
-  () => import("@components/Wiki/SchematicDropInfo")
+  () => import("@components/Wiki/SchematicDropInfo"),
 );
 const DropsInfo = React.lazy(() => import("@components/Wiki/DropsInfo"));
 const CanBeUsedInfo = React.lazy(
-  () => import("@components/Wiki/CanBeUsedInfo")
+  () => import("@components/Wiki/CanBeUsedInfo"),
 );
 const SchematicItems = React.lazy(
-  () => import("@components/Wiki/SchematicItems")
+  () => import("@components/Wiki/SchematicItems"),
 );
 const CreatureDropsInfo = React.lazy(
-  () => import("@components/Wiki/CreatureDropsInfo")
+  () => import("@components/Wiki/CreatureDropsInfo"),
 );
 
 const ItemWiki = () => {
   const { t } = useTranslation();
-  const { name } = useParams();
+  const navigate = useNavigate();
+  const { name, rarity: rarityParam } = useParams();
   const [item, setItem] = useState<Item>();
   const [itemInfo, setItemInfo] = useState<ItemCompleteInfo>();
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [allItems, setAllItems] = useState<Item[]>([]);
-  const [rarity, setRarity] = useState<string>("Common");
   const [textColor, setTextColor] = useState<string>("text-gray-400");
+
+  const rarity = (rarityParam as Rarity) ?? Rarity.Common;
 
   useEffect(() => {
     const loadData = async () => {
@@ -63,7 +65,7 @@ const ItemWiki = () => {
       const items = await getItems();
       if (items) {
         const foundItem = items.find(
-          (it) => it.name.toLowerCase() === itemName
+          (it) => it.name.toLowerCase() === itemName,
         );
         setItem(foundItem);
         setAllItems(items);
@@ -117,13 +119,11 @@ const ItemWiki = () => {
           </div>
         </div>
       ),
-    [itemInfo?.description, t]
+    [itemInfo?.description, t],
   );
 
-  const updateRarity = useCallback((value: Rarity) => {
-    setRarity(value);
-
-    switch (value) {
+  useEffect(() => {
+    switch (rarity) {
       case Rarity.Common:
         setTextColor("text-gray-400");
         break;
@@ -142,7 +142,16 @@ const ItemWiki = () => {
       default:
         setTextColor("text-gray-400");
     }
-  }, []);
+  }, [rarity]);
+
+  const updateRarity = useCallback(
+    (value: Rarity) => {
+      if (name) {
+        navigate(getItemUrl(name, value));
+      }
+    },
+    [name, navigate],
+  );
 
   const getRarityClass = useCallback(
     (value: Rarity) => {
@@ -187,7 +196,7 @@ const ItemWiki = () => {
         rarity === value ? "bg-opacity-20" : ""
       }`;
     },
-    [rarity]
+    [rarity],
   );
 
   const loadingItemPart = () => (
@@ -220,7 +229,7 @@ const ItemWiki = () => {
       <HeaderMeta
         title={`${itemName} - Stiletto for Last Oasis`}
         description={`All information for ${itemName}`}
-        cannonical={getItemUrl(itemName)}
+        cannonical={getItemUrl(itemName, rarity)}
       />
       <div className="flex flex-wrap -mx-4">
         <div className="w-full md:w-1/2 px-4">
@@ -287,7 +296,7 @@ const ItemWiki = () => {
                         rarity,
                         "weight",
                         itemInfo.category,
-                        itemInfo.weight
+                        itemInfo.weight,
                       )}
                     </div>
                   </li>
@@ -302,7 +311,7 @@ const ItemWiki = () => {
                         rarity,
                         "experiencieReward",
                         itemInfo.category,
-                        itemInfo.experiencieReward
+                        itemInfo.experiencieReward,
                       )}
                     </div>
                   </li>
@@ -315,7 +324,7 @@ const ItemWiki = () => {
                         rarity,
                         "durability",
                         itemInfo.category,
-                        itemInfo.durability
+                        itemInfo.durability,
                       )}
                     </div>
                   </li>
@@ -345,8 +354,8 @@ const ItemWiki = () => {
                     type="button"
                     aria-pressed={rarity === rar}
                     className={`${getRarityClass(
-                      rar
-                    )} flex items-center justify-center px-3 py-2 w-[100px] h-[40px] font-medium text-sm focus:z-10 ${
+                      rar,
+                    )} flex capitalize items-center justify-center px-3 py-2 w-[100px] h-[40px] font-medium text-sm focus:z-10 ${
                       rarity === rar ? "ring-2 ring-opacity-50" : ""
                     }`}
                     onClick={() => updateRarity(rar)}

--- a/src/pages/ItemWiki.tsx
+++ b/src/pages/ItemWiki.tsx
@@ -229,7 +229,7 @@ const ItemWiki = () => {
       <HeaderMeta
         title={`${itemName} - Stiletto for Last Oasis`}
         description={`All information for ${itemName}`}
-        cannonical={getItemUrl(itemName, rarity)}
+        canonical={getItemUrl(itemName, rarity)}
       />
       <div className="flex flex-wrap -mx-4">
         <div className="w-full md:w-1/2 px-4">

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -23,7 +23,7 @@ const MapPage: React.FC = () => {
       <HeaderMeta
         title="Interactive Resource Map - Stiletto for Last Oasis"
         description="Interactive Map of resources shared through a link"
-        cannonical={`${getDomain()}/map`}
+        canonical={`${getDomain()}/map`}
       >
         <meta
           name="twitter:image"

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -13,7 +13,7 @@ const Privacy = () => {
       <HeaderMeta
         title={t("privacy.title")}
         description={t("privacy.description")}
-        cannonical={canonicalUrl}
+        canonical={canonicalUrl}
       />
       <div className="w-full mb-8">
         <h2 className="text-3xl font-bold text-gray-300 text-center mb-4">

--- a/src/pages/TechTree.tsx
+++ b/src/pages/TechTree.tsx
@@ -267,7 +267,7 @@ const TechTree = () => {
         <HeaderMeta
           title="Tech Tree - Stiletto for Last Oasis"
           description="View and control your clan's technology tree"
-          cannonical={`${getDomain()}/tech`}
+          canonical={`${getDomain()}/tech`}
         />
         <LoadingScreen />
       </Fragment>
@@ -279,7 +279,7 @@ const TechTree = () => {
       <HeaderMeta
         title="Tech Tree - Stiletto for Last Oasis"
         description="View and control your clan's technology tree"
-        cannonical={`${getDomain()}/tech`}
+        canonical={`${getDomain()}/tech`}
       />
       <nav className="w-full">
         <div

--- a/src/pages/Wiki.tsx
+++ b/src/pages/Wiki.tsx
@@ -308,7 +308,7 @@ const Wiki = () => {
       <HeaderMeta
         title="Wiki - Stiletto for Last Oasis"
         description="Last oasis Wiki"
-        cannonical={`${getDomain()}/wiki`}
+        canonical={`${getDomain()}/wiki`}
       />
       <div className="w-full mb-8">
         <div className="bg-gray-800 border border-gray-700 rounded-lg overflow-hidden shadow-lg">

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -39,6 +39,7 @@ const AppRoutes: React.ReactElement = (
     <Route path="tech/" element={<TechTree />} />
     <Route path="privacy" element={<Privacy />} />
     <Route path="item/:name" element={<ItemWiki />} />
+    <Route path="item/:name/:rarity" element={<ItemWiki />} />
     <Route path="item" element={<Wiki />} />
     <Route path="creature/:name" element={<CreatureWiki />} />
     <Route path="creature" element={<Wiki />} />

--- a/src/store/userStore.tsx
+++ b/src/store/userStore.tsx
@@ -132,7 +132,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
       refreshUserProfile,
     }),
     // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
-    [isConnected, userProfile, isLoading, login, logout, refreshUserProfile]
+    [isConnected, userProfile, isLoading, login, logout, refreshUserProfile],
   );
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -1,9 +1,9 @@
 export enum Rarity {
-  Common = "Common",
-  Uncommon = "Uncommon",
-  Rare = "Rare",
-  Epic = "Epic",
-  Legendary = "Legendary",
+  Common = "common",
+  Uncommon = "uncommon",
+  Rare = "rare",
+  Epic = "epic",
+  Legendary = "legendary",
 }
 
 export type ItemIngredient = {


### PR DESCRIPTION
This commit introduces the ability to include the item's rarity in the URL path, allowing for direct linking to specific rarity states. Additionally, the `Rarity` enum values are updated to lowercase for consistency. Changes include:
- Added `rarity` parameter to `getItemUrl` function and corresponding route.
- Updated `Rarity` enum values to lowercase.
- Modified `ItemWiki` component to handle the new URL parameter and update the UI accordingly.

## Summary by Sourcery

Add support for specifying item rarity in item URLs and update the Rarity enum for consistency.

New Features:
- Enable item URLs to include an optional rarity parameter for direct linking to specific rarity states.

Enhancements:
- Update Rarity enum values to use lowercase for consistency.
- Update ItemWiki component and routing to handle the new rarity URL parameter and reflect it in the UI.