### PR TITLE
refactor: replace FontAwesome icons with React Icons for consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,10 +75,6 @@
     </script>
     <div class="flex flex-col h-full" id="root"></div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <script
-      src="https://kit.fontawesome.com/bba734017e.js"
-      crossorigin="anonymous"
-    ></script>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "19.1.0",
     "react-helmet": "6.1.0",
     "react-i18next": "15.5.1",
+    "react-icons": "^4.12.0",
     "react-leaflet": "4.2.1",
     "react-router": "^7.5.2",
     "vanilla-cookieconsent": "3.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       react-i18next:
         specifier: 15.5.1
         version: 15.5.1(i18next@25.1.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
+      react-icons:
+        specifier: ^4.12.0
+        version: 4.12.0(react@19.1.0)
       react-leaflet:
         specifier: 4.2.1
         version: 4.2.1(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1342,6 +1345,11 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  react-icons@4.12.0:
+    resolution: {integrity: sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==}
+    peerDependencies:
+      react: '*'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -2690,6 +2698,10 @@ snapshots:
     optionalDependencies:
       react-dom: 19.1.0(react@19.1.0)
       typescript: 5.8.3
+
+  react-icons@4.12.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   react-is@16.13.1: {}
 

--- a/src/components/AuctionTimers/Timer.tsx
+++ b/src/components/AuctionTimers/Timer.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import FaIcon from "@components/FaIcon";
 
 interface TimerProps {
   value?: boolean;
@@ -122,14 +123,14 @@ const Timer: React.FC<TimerProps> = ({ value, onPlay }) => {
                 setIsFinish(false);
               }}
             >
-              <i className="fas fa-play mr-2" /> {t("common.start")}
+              <FaIcon icon="fas fa-play" className="mr-2" /> {t("common.start")}
             </button>
             <button
               type="button"
               className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 flex items-center justify-center"
               onClick={() => setIsOn(false)}
             >
-              <i className="fas fa-stop mr-2" /> {t("common.stop")}
+              <FaIcon icon="fas fa-stop" className="mr-2" /> {t("common.stop")}
             </button>
           </div>
         </div>

--- a/src/components/ClanMaps/ClanMapItem.tsx
+++ b/src/components/ClanMaps/ClanMapItem.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useTranslation } from "react-i18next";
 import { memo, useCallback, useMemo } from "react";
+import FaIcon from "@components/FaIcon";
 import { useUser } from "@store/userStore";
 import { getDomain } from "@functions/utils";
 import { config } from "@config/config";
@@ -56,7 +57,7 @@ const ClanMapItem: React.FC<ClanMapItemProps> = ({
           className="w-full p-2 bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500"
           onClick={handleDeleteMap}
         >
-          <i className="fas fa-trash-alt mr-2" /> {t("maps.deleteMap")}
+          <FaIcon icon="fas fa-trash-alt" className="mr-2" /> {t("maps.deleteMap")}
         </button>
       </div>
     );
@@ -75,7 +76,7 @@ const ClanMapItem: React.FC<ClanMapItemProps> = ({
           className="w-full p-2 bg-green-600 text-white rounded-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500"
           onClick={handleShareMap}
         >
-          <i className="fas fa-share-alt mr-2" /> {t("maps.shareMap")}
+          <FaIcon icon="fas fa-share-alt" className="mr-2" /> {t("maps.shareMap")}
         </button>
       </div>
     );
@@ -104,7 +105,7 @@ const ClanMapItem: React.FC<ClanMapItemProps> = ({
               className="w-full p-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
               onClick={handleOpenMap}
             >
-              <i className="fas fa-eye mr-2" /> {t("maps.showMap")}
+              <FaIcon icon="fas fa-eye" className="mr-2" /> {t("maps.showMap")}
             </button>
             {renderDeleteButton}
             {renderShareButton}

--- a/src/components/ClanMaps/ResourceMap.tsx
+++ b/src/components/ClanMaps/ResourceMap.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useState, useEffect, useCallback, memo } from "react";
+import FaIcon from "@components/FaIcon";
 import { useTranslation } from "react-i18next";
 import { getMarkers } from "@functions/github";
 import { useUser } from "@store/userStore";
@@ -296,7 +297,7 @@ const ResourceMap: React.FC<ResourceMapProps> = ({ map, onReturn }) => {
           className="text-white text-xl flex items-center"
           aria-live="polite"
         >
-          <i className="fas fa-circle-notch fa-spin mr-2" />
+          <FaIcon icon="fas fa-circle-notch" className="mr-2 animate-spin" />
           {t("maps.loadingResources")}
         </div>
       </div>

--- a/src/components/ClanMaps/ResourceMapNoLog.tsx
+++ b/src/components/ClanMaps/ResourceMapNoLog.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useState, useEffect, useCallback } from "react";
+import FaIcon from "@components/FaIcon";
 import { useTranslation } from "react-i18next";
 import queryString from "query-string";
 import { getMarkers } from "@functions/github";
@@ -211,7 +212,7 @@ const ResourceMapNoLog: React.FC<ResourceMapNoLogProps> = (props) => {
         onClick={() => setIsOpenSidebar(!isOpenSidebar)}
         className="lg:hidden fixed top-9 left-4 z-50 p-2 bg-gray-800 text-white rounded-lg shadow-lg hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
       >
-        <i className={`fas ${isOpenSidebar ? "fa-times" : "fa-bars"}`} />
+        <FaIcon icon={`fas ${isOpenSidebar ? "fa-times" : "fa-bars"}`} />
       </button>
       <div
         className={`fixed lg:relative inset-y-0 right-0 z-40 w-full lg:w-1/4 bg-gray-800 border-l border-gray-700 transform transition-transform duration-300 ease-in-out z-10 ${

--- a/src/components/Crafter/Item.tsx
+++ b/src/components/Crafter/Item.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import { useTranslation } from "react-i18next";
 import { memo } from "react";
 import type { Item as ItemType } from "@ctypes/item";
+import FaIcon from "@components/FaIcon";
 
 interface ItemProps {
   item: ItemType | null;
@@ -28,7 +29,7 @@ const Item: React.FC<ItemProps> = memo(({ item, onAdd }) => {
           aria-label={t("common.addItem")}
           onClick={() => onAdd(item?.name)}
         >
-          <i className="fas fa-plus" />
+          <FaIcon icon="fas fa-plus" className="ml-1" />
         </button>
       </div>
     </div>

--- a/src/components/Crafter/TotalMaterials.tsx
+++ b/src/components/Crafter/TotalMaterials.tsx
@@ -9,6 +9,7 @@ import { getDomain, getItemUrl } from "@functions/utils";
 import { addRecipe } from "@functions/requests/recipes";
 import type { CraftItem, ItemIngredient } from "@ctypes/item";
 import type { Recipe } from "@ctypes/dto/recipe";
+import FaIcon from "@components/FaIcon";
 
 interface TotalMaterialsProps {
   selectedItems: CraftItem[];
@@ -52,7 +53,8 @@ const TotalMaterials: React.FC<TotalMaterialsProps> = memo(
           data-testid="share-crafter-btn"
           disabled={selectedItems?.length <= 0}
         >
-          <i className="fas fa-share-alt" /> {t("common.share")}
+          <FaIcon icon="fas fa-share-alt" className="mr-1" />{" "}
+          {t("common.share")}
         </button>
       ),
       [addRecipeRequest, selectedItems, t],
@@ -171,7 +173,7 @@ const TotalMaterials: React.FC<TotalMaterialsProps> = memo(
             onClick={copyMaterials}
             disabled={selectedItems?.length <= 0}
           >
-            <i className="fas fa-copy" />
+            <FaIcon icon="fas fa-copy" />
           </button>
         </div>
         <div className="p-4" id="list-all-items">

--- a/src/components/CraftingTime.tsx
+++ b/src/components/CraftingTime.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useTranslation } from "react-i18next";
+import FaIcon from "@components/FaIcon";
 
 interface CraftingTimeProps {
   total?: number;
@@ -36,7 +37,7 @@ const CraftingTime: React.FC<CraftingTimeProps> = ({ total = 1, time }) => {
       <div className="flex items-center justify-end space-x-2 text-gray-300">
         <span>{t("Crafting time")}:</span>
         <div className="flex items-center space-x-2 bg-gray-700 px-3 py-1 rounded-lg">
-          <i className="fa fa-clock" />
+          <FaIcon icon="fa fa-clock" />
           <span className="font-medium">{convertSecondsToTime(totalTime)}</span>
         </div>
       </div>

--- a/src/components/Diplomacy/ClanSelect.tsx
+++ b/src/components/Diplomacy/ClanSelect.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { memo } from "react";
+import FaIcon from "../FaIcon";
 import ClanName from "../ClanName";
 import type { RelationshipInfo } from "@ctypes/dto/relationship";
 
@@ -26,7 +27,7 @@ const ClanSelect: React.FC<ClanSelectProps> = ({
           onClick={() => onDelete(clan?.id)}
           aria-label="Delete relationship"
         >
-          <i className="fas fa-trash" />
+          <FaIcon icon="fas fa-trash" />
         </button>
       </div>
     </div>

--- a/src/components/DiscordButton.tsx
+++ b/src/components/DiscordButton.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { getDomain } from "@functions/utils";
 import { config } from "@config/config";
 import { useUser } from "@store/userStore";
+import FaIcon from "./FaIcon";
 
 const DiscordButton: React.FC = () => {
   const { t } = useTranslation();
@@ -16,7 +17,7 @@ const DiscordButton: React.FC = () => {
         to="/profile"
         data-testid="profile-link"
       >
-        <i className="far fa-user mr-2" /> {t("menu.profile")}
+        <FaIcon icon="far fa-user" className="mr-2" /> {t("menu.profile")}
       </Link>
     );
   }
@@ -30,7 +31,8 @@ const DiscordButton: React.FC = () => {
       className="px-4 py-2 text-sm font-medium text-white border border-gray-600 rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
       href={discordAuthUrl}
     >
-      <i className="fab fa-discord mr-2" /> {t("auth.loginWithDiscord")}
+      <FaIcon icon="fab fa-discord" className="mr-2" />
+      {t("auth.loginWithDiscord")}
     </a>
   );
 };

--- a/src/components/DiscordConnection/PrivateProfile.tsx
+++ b/src/components/DiscordConnection/PrivateProfile.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import i18next from "i18next";
+import FaIcon from "../FaIcon";
 import { Helmet } from "react-helmet";
 import { Link } from "react-router";
 import LoadingScreen from "../LoadingScreen";
@@ -211,14 +212,14 @@ const PrivateProfile = () => {
                   to="/members"
                   className="w-full inline-flex items-center p-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 focus:outline-none"
                 >
-                  <i className="fas fa-users mr-2" />
+                  <FaIcon icon="fas fa-users" className="mr-2" />
                   {t("menu.clanGeneral")}
                 </Link>
                 <Link
                   to="/diplomacy"
                   className="w-full inline-flex items-center p-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 focus:outline-none"
                 >
-                  <i className="far fa-flag mr-2" />
+                  <FaIcon icon="far fa-flag" className="mr-2" />
                   {t("menu.diplomacy")}
                 </Link>
                 {isLoaded && userData?.discordid !== userData?.leaderid && (

--- a/src/components/FaIcon.tsx
+++ b/src/components/FaIcon.tsx
@@ -1,0 +1,108 @@
+import type React from "react";
+import {
+  FaTools,
+  FaShareAlt,
+  FaCopy,
+  FaPlus,
+  FaPlay,
+  FaStop,
+  FaUserCog,
+  FaCrown,
+  FaUsersCog,
+  FaVolumeUp,
+  FaVolumeMute,
+  FaMinus,
+  FaChevronUp,
+  FaChevronDown,
+  FaTrash,
+  FaUsers,
+  FaCheck,
+  FaTimes,
+  FaSave,
+  FaTrashAlt,
+  FaEye,
+  FaEyeSlash,
+  FaClock,
+  FaCircleNotch,
+  FaBars,
+  FaSearch,
+  FaList,
+} from "react-icons/fa";
+import { FaDiscord } from "react-icons/fa6";
+import {
+  FaFlag,
+  FaUser,
+  FaArrowAltCircleUp,
+  FaArrowAltCircleDown,
+} from "react-icons/fa";
+
+interface FaIconProps {
+  icon: string;
+  className?: string;
+  size?: number;
+  title?: string;
+}
+
+/**
+ * Componente que reemplaza los iconos de FontAwesome con React Icons
+ */
+const FaIcon: React.FC<FaIconProps> = ({
+  icon,
+  className = "",
+  size = 16,
+  title,
+}) => {
+  // Mapeo de iconos de FontAwesome a componentes de React Icons
+  const iconMap: Record<string, React.ComponentType<any>> = {
+    "fas fa-tools": FaTools,
+    "fas fa-share-alt": FaShareAlt,
+    "fas fa-copy": FaCopy,
+    "fas fa-plus": FaPlus,
+    "fab fa-discord": FaDiscord,
+    "fas fa-play": FaPlay,
+    "fas fa-stop": FaStop,
+    "fas fa-user-cog": FaUserCog,
+    "fas fa-crown": FaCrown,
+    "fas fa-users-cog": FaUsersCog,
+    "fas fa-volume-up": FaVolumeUp,
+    "fas fa-volume-mute": FaVolumeMute,
+    "fas fa-minus": FaMinus,
+    "fas fa-chevron-up": FaChevronUp,
+    "fas fa-chevron-down": FaChevronDown,
+    "fas fa-trash": FaTrash,
+    "fas fa-users": FaUsers,
+    "far fa-flag": FaFlag,
+    "far fa-user": FaUser,
+    "fas fa-check": FaCheck,
+    "fas fa-times": FaTimes,
+    "fas fa-save": FaSave,
+    "fas fa-trash-alt": FaTrashAlt,
+    "fas fa-eye": FaEye,
+    "fas fa-eye-slash": FaEyeSlash,
+    "fa fa-clock": FaClock,
+    "fas fa-circle-notch": FaCircleNotch,
+    "fas fa-bars": FaBars,
+    "fa fa-search": FaSearch,
+    "far fa-arrow-alt-circle-up": FaArrowAltCircleUp,
+    "far fa-arrow-alt-circle-down": FaArrowAltCircleDown,
+    "fas fa-list": FaList,
+  };
+
+  const IconComponent = iconMap[icon];
+
+  if (!IconComponent) {
+    console.warn(`No se encontró el icono: ${icon}`);
+    return null;
+  }
+
+  return (
+    <IconComponent
+      className={className}
+      size={size}
+      title={title}
+      aria-hidden={!title}
+    />
+  );
+};
+
+export default FaIcon;

--- a/src/components/Ingredient.tsx
+++ b/src/components/Ingredient.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useState, memo } from "react";
 import { useTranslation } from "react-i18next";
+import FaIcon from "@components/FaIcon";
 import Icon from "./Icon";
 import Ingredients from "./Ingredients";
 import { getItemUrl } from "@functions/utils";
@@ -68,8 +69,9 @@ const Ingredient: React.FC<IngredientProps> = memo(({ ingredient, value }) => {
                 {t(ingredient?.name, { ns: "items" })}
               </span>
               <span className="ml-2 text-gray-400 bg-gray-700 rounded-full w-5 h-5 flex items-center justify-center">
-                <i
-                  className={`fas fa-chevron-${showList ? "up" : "down"} text-xs`}
+                <FaIcon
+                  icon={`fas fa-chevron-${showList ? "up" : "down"}`}
+                  className="text-xs"
                 />
               </span>
             </div>

--- a/src/components/MemberList/MemberListItem.tsx
+++ b/src/components/MemberList/MemberListItem.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useTranslation } from "react-i18next";
+import FaIcon from "../FaIcon";
 import type { MemberInfo } from "@ctypes/dto/members";
 import { useUser } from "@store/userStore";
 
@@ -66,7 +67,7 @@ const MemberListItem: React.FC<MemberListItemProps> = ({
             className="px-2 py-1 bg-blue-600 text-white rounded-l-lg flex items-center justify-center"
             disabled
           >
-            <i className="fas fa-user-cog" />
+            <FaIcon icon="fas fa-user-cog" />
           </button>
           <button
             type="button"
@@ -84,7 +85,7 @@ const MemberListItem: React.FC<MemberListItemProps> = ({
     <tr className="hover:bg-gray-700 transition-colors duration-150">
       <td className="px-4 py-3">
         {member.leaderid === member.discordid && (
-          <i className="fas fa-crown text-yellow-400 mr-1" />
+          <FaIcon icon="fas fa-crown" className="text-yellow-400 mr-1" />
         )}
         <span className="font-medium text-neutral-400">
           {member.discordtag}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useState, useRef, type KeyboardEvent } from "react";
+import FaIcon from "./FaIcon";
 import LanguageLink from "./LanguageLink";
 import DiscordButton from "./DiscordButton";
 import { useTranslation } from "react-i18next";
@@ -181,7 +182,7 @@ const Menu: React.FC<MenuProps> = ({
                   className="absolute right-2 top-1/2 transform -translate-y-1/2 text-gray-600 hover:text-gray-800"
                   onClick={searchItem}
                 >
-                  <i className="fa fa-search" />
+                  <FaIcon icon="fa fa-search" />
                 </button>
               </div>
 

--- a/src/components/SearchableSelect.tsx
+++ b/src/components/SearchableSelect.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import FaIcon from "@components/FaIcon";
 
 interface SearchableSelectProps {
   id: string;
@@ -84,7 +85,7 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
         data-testid={dataCy}
       >
         <span>{selectedLabel ?? placeholder}</span>
-        <i className={`fas fa-chevron-${isOpen ? "up" : "down"}`} />
+        <FaIcon icon={`fas fa-chevron-${isOpen ? "up" : "down"}`} />
       </div>
 
       {isOpen && (

--- a/src/components/TradeSystem/Trade.tsx
+++ b/src/components/TradeSystem/Trade.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useTranslation } from "react-i18next";
 import Icon from "../Icon";
+import FaIcon from "@components/FaIcon";
 import type { TradeInfo } from "@ctypes/dto/trades";
 
 interface TradeProps {
@@ -31,7 +32,7 @@ const Trade: React.FC<TradeProps> = ({ trade, onDelete, userDiscordId }) => {
               aria-label="Send DM"
               data-testid="discord-link"
             >
-              <i className="fab fa-discord" />
+              <FaIcon icon="fab fa-discord" />
             </a>
           </div>
         </div>
@@ -88,9 +89,9 @@ const Trade: React.FC<TradeProps> = ({ trade, onDelete, userDiscordId }) => {
         >
           <div className="flex items-center justify-center space-x-2">
             {trade.type === "Supply" ? (
-              <i className="far fa-arrow-alt-circle-up text-green-400" />
+              <FaIcon icon="far fa-arrow-alt-circle-up" className="text-green-400" />
             ) : (
-              <i className="far fa-arrow-alt-circle-down text-red-400" />
+              <FaIcon icon="far fa-arrow-alt-circle-down" className="text-red-400" />
             )}
             <span className="text-gray-300" data-testid="trade-type-region">
               {t(trade.type)} {"//"} {trade.region}

--- a/src/components/WalkerList/WalkerListItem.tsx
+++ b/src/components/WalkerList/WalkerListItem.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import { useState, useCallback, memo } from "react";
 import { useTranslation } from "react-i18next";
 import Icon from "../Icon";
+import FaIcon from "../FaIcon";
 import type { MemberInfo } from "@ctypes/dto/members";
 import type { WalkerInfo } from "@ctypes/dto/walkers";
 
@@ -240,7 +241,7 @@ const WalkerListItem: React.FC<WalkerListItemProps> = ({
                     }`}
                     onClick={() => handleWalkerUpdate("isReady", true)}
                   >
-                    <i className="fas fa-check" />
+                    <FaIcon icon="fas fa-check" />
                   </button>
                   <span className="p-2 bg-gray-700 text-gray-300">
                     {t("common.isReady")}
@@ -254,7 +255,7 @@ const WalkerListItem: React.FC<WalkerListItemProps> = ({
                     }`}
                     onClick={() => handleWalkerUpdate("isReady", false)}
                   >
-                    <i className="fas fa-times" />
+                    <FaIcon icon="fas fa-times" />
                   </button>
                 </div>
 
@@ -266,7 +267,7 @@ const WalkerListItem: React.FC<WalkerListItemProps> = ({
                     setIsOpen(false);
                   }}
                 >
-                  <i className="fas fa-save mr-2" /> {t("common.save")}
+                  <FaIcon icon="fas fa-save" className="mr-2" /> {t("common.save")}
                 </button>
 
                 {canEdit && (
@@ -275,7 +276,7 @@ const WalkerListItem: React.FC<WalkerListItemProps> = ({
                     className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 w-full max-w-xs"
                     onClick={() => onRemove(walker.walkerid)}
                   >
-                    <i className="fas fa-trash-alt mr-2" /> {t("common.delete")}
+                    <FaIcon icon="fas fa-trash-alt" className="mr-2" /> {t("common.delete")}
                   </button>
                 )}
               </div>
@@ -323,10 +324,9 @@ const WalkerListItem: React.FC<WalkerListItemProps> = ({
           {walker.description}
         </td>
         <td className="px-6 py-4 text-center whitespace-nowrap">
-          <i
-            className={`fas fa-${
-              walker.isReady ? "check text-green-500" : "times text-red-500"
-            }`}
+          <FaIcon 
+            icon={`fas fa-${walker.isReady ? "check" : "times"}`}
+            className={walker.isReady ? "text-green-500" : "text-red-500"}
           />
         </td>
         <td className="px-6 py-4 text-center whitespace-nowrap">
@@ -338,7 +338,7 @@ const WalkerListItem: React.FC<WalkerListItemProps> = ({
               isOpen ? t("common.hideDetails") : t("common.showDetails")
             }
           >
-            <i className={`fas fa-eye${isOpen ? "-slash" : ""}`} />
+            <FaIcon icon={`fas fa-eye${isOpen ? "-slash" : ""}`} />
           </button>
         </td>
       </tr>

--- a/src/pages/AuctionTimers.tsx
+++ b/src/pages/AuctionTimers.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, memo } from "react";
 import { useTranslation } from "react-i18next";
+import FaIcon from "@components/FaIcon";
 import Timer from "@components/AuctionTimers/Timer";
 import { getDomain } from "@functions/utils";
 import HeaderMeta from "@components/HeaderMeta";
@@ -59,7 +60,7 @@ const AuctionTimers = memo(() => {
                   } rounded-l-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 flex items-center justify-center`}
                   onClick={() => setPlaySound(true)}
                 >
-                  <i className="fas fa-volume-up mr-2" /> {t("common.soundOn")}
+                  <FaIcon icon="fas fa-volume-up" className="mr-2" /> {t("common.soundOn")}
                 </button>
                 <button
                   type="button"
@@ -70,7 +71,7 @@ const AuctionTimers = memo(() => {
                   } rounded-r-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 flex items-center justify-center`}
                   onClick={() => setPlaySound(false)}
                 >
-                  <i className="fas fa-volume-mute mr-2" />{" "}
+                  <FaIcon icon="fas fa-volume-mute" className="mr-2" />{" "}
                   {t("common.soundOff")}
                 </button>
               </div>
@@ -90,7 +91,7 @@ const AuctionTimers = memo(() => {
                 className="px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 text-lg font-medium"
                 onClick={() => setTimers(timers + 1)}
               >
-                <i className="fas fa-plus mr-2" />
+                <FaIcon icon="fas fa-plus" className="mr-2" />
                 {t("Add Timer")}
               </button>
               <button
@@ -101,7 +102,7 @@ const AuctionTimers = memo(() => {
                 onClick={() => setTimers(Math.max(1, timers - 1))}
                 disabled={timers <= 1}
               >
-                <i className="fas fa-minus mr-2" />
+                <FaIcon icon="fas fa-minus" className="mr-2" />
                 {t("Remove Timer")}
               </button>
             </div>

--- a/src/pages/Crafter.tsx
+++ b/src/pages/Crafter.tsx
@@ -12,6 +12,7 @@ import { getRecipe } from "@functions/requests/recipes";
 import { useLocation } from "react-router";
 import type { CraftItem, Item, ItemRecipe } from "@ctypes/item";
 import HeaderMeta from "@components/HeaderMeta";
+import FaIcon from "@components/FaIcon";
 
 const Crafter: React.FC = () => {
   const location = useLocation();
@@ -218,7 +219,7 @@ const Crafter: React.FC = () => {
             aria-expanded={isItemsNavVisible}
             aria-label="Toggle items"
           >
-            <i className="fas fa-list fa-lg" />
+            <FaIcon icon="fas fa-list" size={20} />
           </button>
         </form>
         <nav

--- a/src/pages/DiscordConnection.tsx
+++ b/src/pages/DiscordConnection.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useState, useEffect, useCallback, useMemo } from "react";
+import FaIcon from "@components/FaIcon";
 import { useTranslation } from "react-i18next";
 import queryString from "query-string";
 import LoadingScreen from "@components/LoadingScreen";
@@ -81,7 +82,7 @@ const DiscordConnection: React.FC = () => {
               href={discordLoginUrl}
               className="w-full inline-flex justify-center items-center p-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800 transition-colors"
             >
-              <i className="fab fa-discord mr-2" />
+              <FaIcon icon="fab fa-discord" className="mr-2" />
               {t("auth.loginWithDiscord")}
             </a>
           </div>

--- a/src/pages/ItemWiki.tsx
+++ b/src/pages/ItemWiki.tsx
@@ -25,6 +25,7 @@ import {
 } from "@functions/utils";
 import HeaderMeta from "@components/HeaderMeta";
 import { type Item, type ItemCompleteInfo, Rarity } from "@ctypes/item";
+import FaIcon from "@components/FaIcon";
 
 const WikiDescription = React.lazy(
   () => import("@components/Wiki/WikiDescription"),
@@ -385,7 +386,7 @@ const ItemWiki = () => {
                   href={craftUrl}
                   className="text-gray-400 hover:text-gray-300"
                 >
-                  <i className="fas fa-tools" />
+                  <FaIcon icon="fas fa-tools" />
                 </a>
               </div>
               <div className="p-4 flex flex-wrap">{showIngredient(item)}</div>

--- a/src/pages/MemberList.tsx
+++ b/src/pages/MemberList.tsx
@@ -7,6 +7,7 @@ import ClanConfig from "@components/ClanConfig";
 import MemberListItem from "@components/MemberList/MemberListItem";
 import RequestMemberListItem from "@components/MemberList/RequestMemberListItem";
 import MemberPermissionsConfig from "@components/MemberList/MemberPermissionsConfig";
+import FaIcon from "@components/FaIcon";
 import { sendNotification } from "@functions/broadcast";
 import { getDomain } from "@functions/utils";
 import { getRequests, updateRequest } from "@functions/requests/clans/requests";
@@ -405,7 +406,7 @@ const MemberList = () => {
                 className="px-4 py-2 bg-blue-600 text-white rounded-l-lg flex items-center justify-center"
                 disabled
               >
-                <i className="fas fa-users-cog" />
+                <FaIcon icon="fas fa-users-cog" />
               </button>
               <button
                 type="button"


### PR DESCRIPTION
This commit replaces all FontAwesome icon usage with React Icons to improve consistency and reduce dependency on external CDN. The `FaIcon` component was introduced to map FontAwesome class names to React Icons components. This change also removes the FontAwesome CDN script from `index.html` and adds the `react-icons` package to `package.json`.

## Summary by Sourcery

Refactor icon usage by introducing a FaIcon wrapper for React Icons, replacing all FontAwesome <i> tags, removing the external FontAwesome CDN script, and adding react-icons as a dependency.

Enhancements:
- Introduce a FaIcon component to map FontAwesome class names to React Icons components
- Replace all FontAwesome <i> elements across the app with the new FaIcon wrapper for consistent icon rendering
- Remove the FontAwesome CDN script from index.html

Build:
- Add react-icons package to project dependencies