### PR TITLE
feat: Add GitHub Actions workflow for publishing wiki

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,0 +1,18 @@
+name: Publish wiki
+on:
+  push:
+    branches: [master]
+    paths:
+      - wiki/**
+      - .github/workflows/publish-wiki.yml
+concurrency:
+  group: publish-wiki
+  cancel-in-progress: true
+permissions:
+  contents: write
+jobs:
+  publish-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Andrew-Chen-Wang/github-wiki-action@v4


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a `publish-wiki` GitHub Actions workflow triggered by changes in `wiki/**` and the workflow file