### PR TITLE
feat: Migrate to tanstack router

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@giscus/react": "3.1.0",
+    "@tanstack/react-router": "^1.120.15",
     "@tanstack/react-virtual": "^3.13.9",
     "i18next": "25.2.0",
     "i18next-browser-languagedetector": "8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@giscus/react':
         specifier: 3.1.0
         version: 3.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@tanstack/react-router':
+        specifier: ^1.120.15
+        version: 1.120.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tanstack/react-virtual':
         specifier: ^3.13.9
         version: 3.13.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -735,11 +738,35 @@ packages:
   '@tailwindcss/postcss@4.1.7':
     resolution: {integrity: sha512-88g3qmNZn7jDgrrcp3ZXEQfp9CVox7xjP1HN2TFKI03CltPVd/c61ydn5qJJL8FYunn0OqBaW5HNUga0kmPVvw==}
 
+  '@tanstack/history@1.115.0':
+    resolution: {integrity: sha512-K7JJNrRVvyjAVnbXOH2XLRhFXDkeP54Kt2P4FR1Kl2KDGlIbkua5VqZQD2rot3qaDrpufyUa63nuLai1kOLTsQ==}
+    engines: {node: '>=12'}
+
+  '@tanstack/react-router@1.120.15':
+    resolution: {integrity: sha512-apzBmXh4pHwqUGU3kD8y2FJMi7rVoUbRxh5oV7v8kEb6Aq5Xpdo+OcpThw8h/M2zv7v4Ef8IoY6WFCKKu3HBjQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.7.1':
+    resolution: {integrity: sha512-qUTEKdId6QPWGiWyKAPf/gkN29scEsz6EUSJ0C3HgLMgaqTAyBsQ2sMCfGVcqb+kkhEXAdjleCgH6LAPD6f2sA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/react-virtual@3.13.9':
     resolution: {integrity: sha512-SPWC8kwG/dWBf7Py7cfheAPOxuvIv4fFQ54PdmYbg7CpXfsKxkucak43Q0qKsxVthhUJQ1A7CIMAIplq4BjVwA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.120.15':
+    resolution: {integrity: sha512-soLj+mEuvSxAVFK/3b85IowkkvmSuQL6J0RSIyKJFGFgy0CmUzpcBGEO99+JNWvvvzHgIoY4F4KtLIN+rvFSFA==}
+    engines: {node: '>=12'}
+
+  '@tanstack/store@0.7.1':
+    resolution: {integrity: sha512-PjUQKXEXhLYj2X5/6c1Xn/0/qKY0IVFxTJweopRfF26xfjVyb14yALydJrHupDh3/d+1WKmfEgZPBVCmDkzzwg==}
 
   '@tanstack/virtual-core@3.13.9':
     resolution: {integrity: sha512-3jztt0jpaoJO5TARe2WIHC1UQC3VMLAFUW5mmMo0yrkwtDB2AQP0+sh10BVUpWrnvHjSLvzFizydtEGLCJKFoQ==}
@@ -1742,6 +1769,12 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-warning@1.0.3:
+    resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
+
   tinyglobby@0.2.13:
     resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
     engines: {node: '>=12.0.0'}
@@ -1793,6 +1826,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2415,11 +2453,39 @@ snapshots:
       postcss: 8.5.3
       tailwindcss: 4.1.7
 
+  '@tanstack/history@1.115.0': {}
+
+  '@tanstack/react-router@1.120.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/history': 1.115.0
+      '@tanstack/react-store': 0.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@tanstack/router-core': 1.120.15
+      jsesc: 3.1.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tiny-invariant: 1.3.3
+      tiny-warning: 1.0.3
+
+  '@tanstack/react-store@0.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/store': 0.7.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      use-sync-external-store: 1.5.0(react@19.1.0)
+
   '@tanstack/react-virtual@3.13.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@tanstack/virtual-core': 3.13.9
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+
+  '@tanstack/router-core@1.120.15':
+    dependencies:
+      '@tanstack/history': 1.115.0
+      '@tanstack/store': 0.7.1
+      tiny-invariant: 1.3.3
+
+  '@tanstack/store@0.7.1': {}
 
   '@tanstack/virtual-core@3.13.9': {}
 
@@ -3576,6 +3642,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
+  tiny-warning@1.0.3: {}
+
   tinyglobby@0.2.13:
     dependencies:
       fdir: 6.4.4(picomatch@4.0.2)
@@ -3635,6 +3705,10 @@ snapshots:
       browserslist: 4.24.4
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   util-deprecate@1.0.2: {}
 

--- a/src/CrafterApp.tsx
+++ b/src/CrafterApp.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router";
+import { useNavigate } from "@tanstack/react-router"; // Updated import
 import i18next from "i18next";
 import { supportedLanguages } from "@config/languages";
 import { Helmet } from "react-helmet";
@@ -7,14 +7,18 @@ import VanillaCookieConsent from "@components/VanillaCookieConsent";
 import Menu from "@components/Menu";
 import ChangeLanguageModal from "@components/ChangeLanguageModal";
 import { getStoredItem, storeItem } from "@functions/services";
-import AppRoutes from "./router";
 import { usePageTracking } from "@functions/page-tracking";
 import NotificationList from "@components/Notifications/NotificationList";
 import Footer from "@components/Footer";
-import { UserProvider } from "@store/userStore";
+// UserProvider removed from here
+import { Outlet, useRouterState } from "@tanstack/react-router"; // Added import
 
 const CrafterApp: React.FC = () => {
   const navigate = useNavigate();
+  // Get current location and params for language switching
+  const location = useRouterState({ select: (s) => s.location });
+  const params = useRouterState({ select: (s) => s.params });
+
   const [showChangeLanguageModal, setShowChangeLanguageModal] =
     useState<boolean>(false);
   const [redirectTo, setRedirectTo] = useState<string | null>(null);
@@ -24,62 +28,69 @@ const CrafterApp: React.FC = () => {
   const language = getStoredItem("i18nextLng");
 
   if (redirectTo != null) {
-    navigate(redirectTo);
+    navigate({ to: redirectTo }); // Updated navigate usage
     setRedirectTo(null);
   }
 
   return (
-    <UserProvider>
-      <React.Fragment>
-        <Helmet
-          htmlAttributes={{
-            lang: language ?? "en",
-          }}
-        />
-        <Menu
-          language={language ?? "en"}
-          openLanguajeModal={() => {
-            setShowChangeLanguageModal(true);
-          }}
-          setRedirectTo={(value: string) => setRedirectTo(value)}
-        />
-        <main className="flex-shrink-0">
-          <div className="container-fluid pt-4">
-            {AppRoutes}
-            {showChangeLanguageModal && (
-              <ChangeLanguageModal
-                switchLanguage={(lng: string) => switchLanguage(lng)}
-                hideModal={() => setShowChangeLanguageModal(false)}
-              />
-            )}
-          </div>
-        </main>
-        <Footer />
-        <VanillaCookieConsent />
-        <NotificationList />
-      </React.Fragment>
-    </UserProvider>
+    // UserProvider was removed from here
+    <React.Fragment>
+      <Helmet
+        htmlAttributes={{
+          lang: language ?? "en",
+        }}
+      />
+      <Menu
+        language={language ?? "en"}
+        openLanguajeModal={() => {
+          setShowChangeLanguageModal(true);
+        }}
+        setRedirectTo={(value: string) => setRedirectTo(value)}
+      />
+      <main className="flex-shrink-0">
+        <div className="container-fluid pt-4">
+          <Outlet /> {/* Replaced AppRoutes with Outlet */}
+          {showChangeLanguageModal && (
+            <ChangeLanguageModal
+              switchLanguage={(newLang: string) => switchLanguage(newLang, location, params)}
+              hideModal={() => setShowChangeLanguageModal(false)}
+            />
+          )}
+        </div>
+      </main>
+      <Footer />
+      <VanillaCookieConsent />
+      <NotificationList />
+    </React.Fragment>
+    // UserProvider was removed from here
   );
 };
 
-function switchLanguage(lng: string): void {
+function switchLanguage(lng: string, location: any, routeParams: any): void { // Added location and params
   storeItem("i18nextLng", lng);
   i18next.changeLanguage(lng);
 
-  const currentPath = window.location.pathname;
-  const pathSegments = currentPath.split("/").filter(Boolean);
+  const { lang, ...otherParams } = routeParams as { lang?: string, [key: string]: string };
 
-  const supportedLangCodes = supportedLanguages.map((lang) => lang.key);
-  const firstSegment = pathSegments[0];
+  let newPathname = location.pathname;
 
-  if (firstSegment && supportedLangCodes.includes(firstSegment)) {
+  // If the first segment is a supported language code, replace it
+  const pathSegments = newPathname.split("/").filter(Boolean);
+  if (pathSegments.length > 0 && supportedLanguages.some(sl => sl.key === pathSegments[0])) {
     pathSegments[0] = lng;
-    const normalizedPath = `/${pathSegments.join("/")}`;
-    window.location.href = `${normalizedPath.replace(/\/+/g, "/")}${window.location.search}`;
+    newPathname = `/${pathSegments.join("/")}`;
   } else {
-    const normalizedPath = `/${lng}${currentPath}`;
-    window.location.href = `${normalizedPath.replace(/\/+/g, "/")}${window.location.search}`;
+    // If no language code is present, or it's not the first segment, prepend the new language code
+    newPathname = `/${lng}${newPathname}`;
   }
+
+  newPathname = newPathname.replace(/\/+/g, "/"); // Normalize multiple slashes
+
+  // Keep existing search parameters
+  const searchString = location.search;
+
+  // For full reload to ensure all components pick up language change through i18next correctly
+  window.location.href = `${newPathname}${searchString}`;
 }
 
 export default CrafterApp;

--- a/src/components/DiscordConnection/PrivateProfile.tsx
+++ b/src/components/DiscordConnection/PrivateProfile.tsx
@@ -1,50 +1,40 @@
 import type React from "react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react"; // Added useCallback
 import { useTranslation } from "react-i18next";
 import i18next from "i18next";
 import { Helmet } from "react-helmet";
-import { Link } from "react-router";
+import { Link, useNavigate } from "@tanstack/react-router"; // Updated Link and added useNavigate
 import LoadingScreen from "../LoadingScreen";
 import ModalMessage from "../ModalMessage";
 import ClanConfig from "../ClanConfig";
-import { getDomain } from "@functions/utils";
-import { deleteUser, addNick, getUser } from "@functions/requests/users";
+import { getDomain, getDiscordLoginUrl } from "@functions/utils"; // Added getDiscordLoginUrl
+import { deleteUser, addNick } from "@functions/requests/users"; // Removed getUser
 import { leaveClan } from "@functions/requests/clans";
 import { supportedLanguages } from "@config/languages";
 import { closeSession } from "@functions/services";
 import { DEFAULT_LANGUAGE } from "@config/config";
-import type { UserInfo } from "@ctypes/dto/users";
+// UserInfo might be implicitly handled by userProfile from useUser
 import { useUser } from "@store/userStore";
-import { FaUsers, FaFlag } from "react-icons/fa";
+import { FaUsers, FaFlag, FaDiscord, FaSignOutAlt, FaPlus } from "react-icons/fa"; // Added more icons
 
 const PrivateProfile = () => {
   const { t, i18n } = useTranslation();
-  const { isConnected } = useUser();
-  const [userData, setUserData] = useState<UserInfo>();
+  const { userProfile, logout, isLoading, refreshUserProfile, isConnected } = useUser(); // Used from context
+  const navigate = useNavigate(); // For navigation
+
   const [language, setLanguage] = useState(i18n.language ?? DEFAULT_LANGUAGE);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [isLoaded, setIsLoaded] = useState(false);
-  const [redirect, setRedirect] = useState(false);
+  const [redirect, setRedirect] = useState(false); // This redirect seems for local component logic
   const [nameInGameInput, setNameInGameInput] = useState("");
   const [error, setError] = useState("");
   const [showCreateClanConfig, setShowCreateClanConfig] = useState(false);
 
   useEffect(() => {
-    const fetchUserProfile = async () => {
-      try {
-        const response = await getUser();
-        setUserData(response);
-        setNameInGameInput(response?.nickname ?? "");
-      } catch {
-        setError("auth.loginAgain1");
-        closeSession();
-      } finally {
-        setIsLoaded(true);
-      }
-    };
-
-    fetchUserProfile();
-  }, []);
+    if (userProfile) {
+      setNameInGameInput(userProfile.nickname ?? "");
+    }
+    // Removed fetchUserProfile as data comes from context
+  }, [userProfile]);
 
   const clearStorageData = () => {
     localStorage.removeItem("profile");
@@ -53,58 +43,61 @@ const PrivateProfile = () => {
     sessionStorage.removeItem("memberList");
   };
 
-  const handleDeleteUser = async () => {
+  const handleDeleteUser = useCallback(async () => { // Wrapped in useCallback
     try {
       await deleteUser();
       clearStorageData();
-      closeSession();
+      closeSession(); // This should also trigger logout from context if implemented there
+      // No need to call refreshUserProfile if user is being deleted and logged out
     } catch {
       setError(t("errors.apiConnection"));
     }
-  };
+  }, [t]); // Added dependencies
 
-  const handleAddNickInGame = async (
+  const handleAddNickInGame = useCallback(async ( // Wrapped in useCallback
     event: React.FormEvent<HTMLFormElement>,
   ) => {
     event.preventDefault();
-    try {
-      await addNick(nameInGameInput);
-      clearStorageData();
+    if (!userProfile?.discordid) return; // Guard clause
 
-      const user = await getUser();
-      setUserData(user);
+    try {
+      await addNick(nameInGameInput); // addNick likely uses userProfile.discordid internally via token
+      clearStorageData(); // This might be redundant if refreshUserProfile handles cache correctly
+      await refreshUserProfile();
+      // setRedirectMessage might be useful if you want to show a success message
     } catch {
       setError(t("errors.apiConnection"));
     }
-  };
+  }, [nameInGameInput, userProfile?.discordid, refreshUserProfile, t]); // Added dependencies
 
-  const handleLeaveClan = async () => {
+  const handleLeaveClan = useCallback(async () => { // Wrapped in useCallback
+    if (!userProfile?.clanid) return; // Guard clause
+
     try {
-      await leaveClan();
-      clearStorageData();
-
-      const response = await getUser();
-
-      setUserData(response);
+      await leaveClan(); // leaveClan likely uses userProfile info internally via token
+      clearStorageData(); // Might be redundant
+      await refreshUserProfile();
     } catch {
       setError(t("errors.apiConnection"));
     }
-  };
+  }, [userProfile?.clanid, refreshUserProfile, t]); // Added dependencies
 
-  const handleLanguageChange = () => {
+  const handleLanguageChange = () => { // This seems fine, relates to i18n local state
     i18next.changeLanguage(language);
   };
 
-  const handleCreateClan = async () => {
+  const handleCreateClan = useCallback(async () => { // Wrapped in useCallback
+    // This function is called from ClanConfig's onClose, implying clan creation might be handled within ClanConfig
+    // Or, it's just to refresh user data after ClanConfig closes.
+    setShowCreateClanConfig(false); // Close the modal first
     try {
-      setShowCreateClanConfig(false);
-      const response = await getUser();
-
-      setUserData(response);
+      await refreshUserProfile(); // Refresh data after modal closes
     } catch {
       setError(t("errors.apiConnection"));
     }
-  };
+  }, [refreshUserProfile, t]); // Added dependencies
+
+  const discordLoginUrl = getDiscordLoginUrl(); // For the login button if user is not found
 
   if (error) {
     return (
@@ -114,17 +107,42 @@ const PrivateProfile = () => {
     );
   }
 
-  if (!isLoaded) {
+  // Use isLoading from context
+  if (isLoading && !userProfile) { // Show loading only if userProfile isn't available yet
     return <LoadingScreen />;
   }
 
-  if (!isConnected || redirect) {
+  // Check if user is connected and profile exists, or if local redirect is set
+  if (!isConnected || redirect) { // redirect is local state, might be for post-action feedback
+    // If not connected and not loading, means user is logged out or session expired
+    // Or if redirect is true after an action
     return (
       <ModalMessage
         message={{ isError: true, text: "auth.loginAgain2", redirectPage: "/" }}
       />
     );
   }
+
+  // If after loading, userProfile is still null/undefined, means user is not logged in
+  if (!userProfile) {
+     return (
+      <div className="w-full max-w-2xl mx-auto">
+        <div className="bg-gray-800 border border-gray-700 rounded-lg overflow-hidden">
+          <div className="p-6 text-center">
+            <p className="text-gray-300 mb-4">{t("errors.noUserData")}</p>
+            <a
+              href={discordLoginUrl}
+              className="inline-flex items-center justify-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              <FaDiscord className="mr-2" />
+              {t("auth.loginWithDiscord")}
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -162,19 +180,19 @@ const PrivateProfile = () => {
               <div className="flex justify-between items-center p-3">
                 <span className="text-gray-300">{t("profile.discordTag")}</span>
                 <span className="text-gray-400" data-testid="discord-tag">
-                  {userData?.discordtag}
+                  {userProfile?.discordtag}
                 </span>
               </div>
               <div className="flex justify-between items-center p-3">
                 <span className="text-gray-300">{t("profile.nickInGame")}</span>
                 <span className="text-gray-400">
-                  {userData?.nickname ?? t("common.notDefined1")}
+                  {userProfile?.nickname ?? t("common.notDefined1")}
                 </span>
               </div>
               <div className="flex justify-between items-center p-3">
                 <span className="text-gray-300">{t("common.clan")}</span>
                 <span className="text-gray-400">
-                  {userData?.clanname ?? t("clan.noClan")}
+                  {userProfile?.clanname ?? t("clan.noClan")}
                 </span>
               </div>
             </div>
@@ -183,8 +201,8 @@ const PrivateProfile = () => {
             <button
               type="button"
               onClick={() => {
-                closeSession();
-                setRedirect(true);
+                logout(); // Use logout from context
+                setRedirect(true); // Local redirect state
               }}
               className="w-full p-3 bg-yellow-500 text-white rounded-lg hover:bg-yellow-600 focus:outline-none"
             >
@@ -206,23 +224,23 @@ const PrivateProfile = () => {
             </h2>
           </div>
           <div className="p-3 space-y-2">
-            {isLoaded && userData?.clanname ? (
+            {userProfile?.clanname ? ( // Check userProfile from context
               <>
                 <Link
-                  to="/members"
+                  to="/members" // Ensure Link is from @tanstack/react-router
                   className="w-full inline-flex items-center p-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 focus:outline-none"
                 >
                   <FaUsers className="mr-2" />
                   {t("menu.clanGeneral")}
                 </Link>
                 <Link
-                  to="/diplomacy"
+                  to="/diplomacy" // Ensure Link is from @tanstack/react-router
                   className="w-full inline-flex items-center p-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 focus:outline-none"
                 >
                   <FaFlag className="mr-2" />
                   {t("menu.diplomacy")}
                 </Link>
-                {isLoaded && userData?.discordid !== userData?.leaderid && (
+                {userProfile?.discordid !== userProfile?.leaderid && (
                   <button
                     type="button"
                     data-testid="leave-clan-btn"
@@ -236,7 +254,7 @@ const PrivateProfile = () => {
             ) : (
               <>
                 <Link
-                  to="/clanlist"
+                  to="/clanlist" // Ensure Link is from @tanstack/react-router
                   data-testid="join-clan-btn"
                   className="w-full inline-flex justify-center items-center p-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none"
                 >
@@ -257,7 +275,7 @@ const PrivateProfile = () => {
         <div className="bg-gray-800 border border-gray-700 rounded-lg overflow-hidden">
           <div className="p-3">
             <Link
-              to="/maps"
+              to="/maps" // Ensure Link is from @tanstack/react-router
               className="w-full inline-flex justify-center items-center p-3 bg-gray-700 text-white rounded-lg hover:bg-gray-600 focus:outline-none"
             >
               {t("menu.resourceMaps")}
@@ -294,41 +312,41 @@ const PrivateProfile = () => {
             </div>
           </div>
         </div>
-        {isLoaded && (
-          <div className="bg-gray-800 border border-gray-700 rounded-lg overflow-hidden">
-            <div className="p-3 bg-gray-900 border-b border-gray-700">
-              <h2 className="text-xl font-bold text-white">
-                {t("profile.addNameInGame")}
-              </h2>
-            </div>
-            <div className="p-3">
-              <form onSubmit={handleAddNickInGame} className="space-y-3">
-                <div>
-                  <label
-                    htmlFor="user_game_name"
-                    className="block text-sm font-medium text-gray-300 mb-1"
-                  >
-                    {t("profile.yourNameInGame")}
-                  </label>
-                  <input
-                    type="text"
-                    className="w-full p-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:outline-none"
-                    name="nameInGameInput"
-                    value={nameInGameInput}
-                    onChange={(e) => setNameInGameInput(e.target.value)}
-                    required
-                  />
-                </div>
-                <button
-                  type="submit"
-                  className="w-full p-3 bg-green-600 text-white rounded-lg hover:bg-green-700 focus:outline-none"
-                >
-                  {t("common.update")}
-                </button>
-              </form>
-            </div>
+        {/* This section for adding/updating nickname seems fine with local state for input */}
+        <div className="bg-gray-800 border border-gray-700 rounded-lg overflow-hidden">
+          <div className="p-3 bg-gray-900 border-b border-gray-700">
+            <h2 className="text-xl font-bold text-white">
+              {t("profile.addNameInGame")}
+            </h2>
           </div>
-        )}
+          <div className="p-3">
+            <form onSubmit={handleAddNickInGame} className="space-y-3">
+              <div>
+                <label
+                  htmlFor="user_game_name"
+                  className="block text-sm font-medium text-gray-300 mb-1"
+                >
+                  {t("profile.yourNameInGame")}
+                </label>
+                <input
+                  type="text"
+                  className="w-full p-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:outline-none"
+                  name="nameInGameInput"
+                  value={nameInGameInput}
+                  onChange={(e) => setNameInGameInput(e.target.value)}
+                  required
+                />
+              </div>
+              <button
+                type="submit"
+                className="w-full p-3 bg-green-600 text-white rounded-lg hover:bg-green-700 focus:outline-none"
+                disabled={nameInGameInput === userProfile?.nickname || nameInGameInput === ""} // Disable if same or empty
+              >
+                {t("common.update")}
+              </button>
+            </form>
+          </div>
+        </div>
       </div>
       {showDeleteModal && (
         <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -383,10 +401,12 @@ const PrivateProfile = () => {
 
       {showCreateClanConfig && (
         <ClanConfig
-          onClose={() => handleCreateClan()}
+          onClose={handleCreateClan} // Changed to pass the function directly
           onError={() => {
             setShowCreateClanConfig(false);
-            window.location.reload();
+            // Consider if reload is still needed or if refreshUserProfile covers it
+            // window.location.reload();
+            refreshUserProfile().catch(() => setError(t("errors.apiConnection")));
           }}
         />
       )}

--- a/src/components/LanguageLink.tsx
+++ b/src/components/LanguageLink.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { Link, type LinkProps } from "react-router";
+import { Link, type LinkProps } from "@tanstack/react-router";
 import { useLanguagePrefix } from "@hooks/useLanguagePrefix";
 
 /**
@@ -20,7 +20,7 @@ const LanguageLink: React.FC<LinkProps> = ({ to, children, ...props }) => {
         };
 
   return (
-    <Link to={newTo} {...props}>
+    <Link to={newTo as any} {...props}> {/* TODO: Fix 'to' prop type */}
       {children}
     </Link>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,18 +1,37 @@
 import { createRoot } from "react-dom/client";
-
 import CrafterApp from "./CrafterApp";
 import "./styles/normalize.css";
 import "./styles/style.css";
 import "./styles/tribal-ui.css";
 import "./styles/desert-theme.css";
-import { BrowserRouter } from "react-router";
 import "./i18n";
-import LanguageRouter from "@components/LanguageRouter";
+import { RouterProvider, createRouter } from "@tanstack/react-router";
+import { routeTree } from "./routeTree"; // Import routeTree
+import { UserProvider } from "./store/userStore";
+import { Suspense } from "react";
+import LoadingScreen from "@components/LoadingScreen";
+import VanillaCookieConsent from "@components/VanillaCookieConsent";
 
-createRoot(document.getElementById("root") as HTMLElement).render(
-  <BrowserRouter>
-    <LanguageRouter>
-      <CrafterApp />
-    </LanguageRouter>
-  </BrowserRouter>,
-);
+// Create a new router instance
+const router = createRouter({ routeTree });
+
+// Register the router instance for type safety
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+const rootElement = document.getElementById("root");
+
+if (rootElement) {
+  const root = createRoot(rootElement);
+  root.render(
+    <Suspense fallback={<LoadingScreen />}>
+      <UserProvider> {/* UserProvider should wrap RouterProvider */}
+        <RouterProvider router={router} />
+      </UserProvider>
+      <VanillaCookieConsent />
+    </Suspense>,
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,7 +4,7 @@ import { memo, useMemo } from "react";
 import Others from "@pages/Others";
 import { useUser } from "@store/userStore";
 import { getDomain } from "@functions/utils";
-import { Link } from "react-router";
+import { Link } from "@tanstack/react-router";
 import HeaderMeta from "@components/HeaderMeta";
 
 const Home: React.FC = () => {

--- a/src/routeTree.tsx
+++ b/src/routeTree.tsx
@@ -1,0 +1,220 @@
+import { RootRoute, Route } from "@tanstack/react-router";
+import CrafterApp from "./CrafterApp"; // Import the main app component
+
+// Import page components
+import Home from "./pages/Home";
+import Crafter from "./pages/Crafter";
+import ClanList from "./pages/ClanList";
+import MemberList from "./pages/MemberList";
+// import WalkerList from "./pages/WalkerList"; // Commented out as it's not in the provided old router
+import ClanMaps from "./pages/ClanMaps";
+import MapDetail from "./pages/MapDetail";
+import MapPage from "./pages/MapPage";
+import AuctionTimers from "./pages/AuctionTimers";
+import TradeSystem from "./pages/TradeSystem";
+import Wiki from "./pages/Wiki";
+import ItemWiki from "./pages/ItemWiki";
+import CreatureWiki from "./pages/CreatureWiki";
+import TechTree from "./pages/TechTree";
+import Diplomacy from "./pages/Diplomacy";
+import Others from "./pages/Others";
+import DiscordConnection from "./pages/DiscordConnection";
+import Privacy from "./pages/Privacy";
+import NotFoundPage from "./pages/NotFound";
+import ResourceMapNoLog from "./components/ClanMaps/ResourceMapNoLog";
+
+// Define a context interface if you need to pass data through context
+interface RouterContext {
+  // auth: AuthContext; // Example, if you have auth context
+  lang?: string;
+}
+
+// Create a pathless root route. This will serve as the main layout.
+const rootRoute = new RootRoute({
+  component: CrafterApp, // CrafterApp will render the <Outlet/> for child routes
+});
+
+// Create a layout route that handles the optional language parameter
+const langLayoutRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: "/$lang?", // Optional language parameter
+  // You can add a component here if this layout needs its own UI, e.g., a language switcher
+  // component: LanguageLayoutComponent,
+});
+
+// Define application routes as children of the langLayoutRoute
+const indexRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "/",
+  component: Home,
+});
+
+const profileRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "profile", // Relative path
+  component: DiscordConnection,
+});
+
+const crafterRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "crafter",
+  component: Crafter,
+});
+
+const membersRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "members",
+  component: MemberList,
+});
+
+const clanListRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "clanlist",
+  component: ClanList,
+});
+
+const mapsRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "maps",
+  component: ClanMaps,
+});
+
+const mapDetailRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "maps/$id",
+  component: MapDetail,
+});
+
+const tradesRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "trades",
+  component: TradeSystem,
+});
+
+const diplomacyRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "diplomacy",
+  component: Diplomacy,
+});
+
+const auctionsRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "auctions",
+  component: AuctionTimers,
+});
+
+const othersRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "others",
+  component: Others,
+});
+
+// This route seems to be for a public map view, potentially without language prefix?
+// If it should also have lang prefix, it should be a child of langLayoutRoute.
+// For now, making it a child of rootRoute, assuming it might have different layout/handling.
+const mapResourceNoLogRoute = new Route({
+  getParentRoute: () => rootRoute, // Changed parent to rootRoute for distinct handling
+  path: "/map/$id", // Absolute path from root
+  component: ResourceMapNoLog,
+});
+
+const mapPageRoute = new Route({
+  getParentRoute: () => langLayoutRoute, // Or rootRoute if it doesn't need lang
+  path: "map",
+  component: MapPage,
+});
+
+const techTreeRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "tech/$tree",
+  component: TechTree,
+});
+
+const techTreeIndexRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "tech", // Changed from /tech/ to tech to be relative
+  component: TechTree,
+});
+
+const privacyRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "privacy",
+  component: Privacy,
+});
+
+const itemWikiRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "item/$name",
+  component: ItemWiki,
+});
+
+const itemWikiRarityRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "item/$name/$rarity",
+  component: ItemWiki,
+});
+
+const itemIndexRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "item",
+  component: Wiki,
+});
+
+const creatureWikiRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "creature/$name",
+  component: CreatureWiki,
+});
+
+const creatureIndexRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "creature",
+  component: Wiki,
+});
+
+const wikiIndexRoute = new Route({
+  getParentRoute: () => langLayoutRoute,
+  path: "wiki",
+  component: Wiki,
+});
+
+// Catch-all "Not Found" route - should be a child of the layout that applies
+const notFoundRoute = new Route({
+  getParentRoute: () => langLayoutRoute, // Or rootRoute if it's a very generic 404
+  path: "*", // This will catch unmatched paths under the parent
+  component: NotFoundPage,
+});
+
+// Assemble the route tree
+const appRoutes = langLayoutRoute.addChildren([
+  indexRoute,
+  profileRoute,
+  crafterRoute,
+  membersRoute,
+  clanListRoute,
+  mapsRoute,
+  mapDetailRoute,
+  tradesRoute,
+  diplomacyRoute,
+  auctionsRoute,
+  othersRoute,
+  mapPageRoute, // Assuming mapPage needs language context
+  techTreeRoute,
+  techTreeIndexRoute,
+  privacyRoute,
+  itemWikiRoute,
+  itemWikiRarityRoute,
+  itemIndexRoute,
+  creatureWikiRoute,
+  creatureIndexRoute,
+  wikiIndexRoute,
+  notFoundRoute, // This catch-all should be last for this layout
+]);
+
+// Add the language layout and the specific /map/:id route to the root
+export const routeTree = rootRoute.addChildren([
+  appRoutes,
+  mapResourceNoLogRoute,
+  // Consider a root-level catch-all if /map/:id and other potential root paths don't cover all cases
+  // new Route({ getParentRoute: () => rootRoute, path: "*", component: NotFoundPage })
+]);


### PR DESCRIPTION
… done so far and provide feedback for Jules to continue.

## Summary by Sourcery

Migrate the app’s routing to TanStack Router and refactor navigation to use the new router APIs, while overhauling user profile handling to leverage the existing useUser store.

New Features:
- Introduce TanStack Router via a new routeTree definition and RouterProvider, replacing BrowserRouter and custom LanguageRouter.
- Implement optional language parameter in URLs and switchLanguage logic to update paths and reload correctly.

Enhancements:
- Refactor PrivateProfile to consume userProfile from useUser, wrap action handlers in useCallback, add guard clauses and fallback login UI.
- Update CrafterApp to render child routes with Outlet instead of static AppRoutes import.
- Revise switchLanguage to preserve existing pathname and query parameters when changing language.

Build:
- Add @tanstack/react-router and related dependencies to package.json and pnpm-lock.yaml.

Chores:
- Remove BrowserRouter and LanguageRouter wrappers, move UserProvider to index.tsx, and update Link/useNavigate imports throughout the codebase.