### PR TITLE
feat: Adjusting Wiki Pages Generated During the Build

### DIFF
--- a/generate-sitemap.mjs
+++ b/generate-sitemap.mjs
@@ -59,7 +59,15 @@ const SUPPORTED_LANGUAGES = [
   "uk",
 ];
 
+const ITEM_RARITIES = ["common", "uncommon", "rare", "epic", "legendary"];
+
 const toItemPath = (name) => `item/${encodeURI(toCodedName(name))}`;
+const toItemPaths = (name) => [
+  toItemPath(name),
+  ...ITEM_RARITIES.map(
+    (rarity) => `item/${encodeURI(toCodedName(name))}/${rarity}`,
+  ),
+];
 const toCreaturePath = (name) => `creature/${encodeURI(toCodedName(name))}`;
 const trimSlash = (value) => value.replace(/\/+$/, "");
 
@@ -231,7 +239,7 @@ const buildStaticRouteEntries = (baseUrl) => {
   return sortByUrl([...routeMap.values()]);
 };
 
-const buildEntityRouteEntries = (baseUrl, entities, toRoutePath) => {
+const buildEntityRouteEntries = (baseUrl, entities, toRoutePaths) => {
   const routeMap = new Map();
 
   for (const entity of entities) {
@@ -240,11 +248,15 @@ const buildEntityRouteEntries = (baseUrl, entities, toRoutePath) => {
       continue;
     }
 
-    const routePath = toRoutePath(name);
-    routeMap.set(
-      buildRouteUrl(baseUrl, routePath),
-      createRouteEntry(baseUrl, routePath, "weekly", 0.6),
-    );
+    const routePaths = toRoutePaths(name);
+    const normalizedPaths = Array.isArray(routePaths) ? routePaths : [routePaths];
+
+    for (const routePath of normalizedPaths) {
+      routeMap.set(
+        buildRouteUrl(baseUrl, routePath),
+        createRouteEntry(baseUrl, routePath, "weekly", 0.6),
+      );
+    }
   }
 
   return sortByUrl([...routeMap.values()]);
@@ -282,7 +294,7 @@ const run = async () => {
   const creatures = Array.isArray(parsedCreatures) ? parsedCreatures : [];
 
   const staticEntries = buildStaticRouteEntries(baseUrl);
-  const itemEntries = buildEntityRouteEntries(baseUrl, items, toItemPath);
+  const itemEntries = buildEntityRouteEntries(baseUrl, items, toItemPaths);
   const creatureEntries = buildEntityRouteEntries(
     baseUrl,
     creatures,

--- a/src/app/[lang]/creature/[name]/page.tsx
+++ b/src/app/[lang]/creature/[name]/page.tsx
@@ -1,0 +1,77 @@
+import { supportedLanguages } from "@config/languages";
+import type { Creature, CreatureCompleteInfo } from "@ctypes/creature";
+import I18nProviderClient from "@components/I18nProviderClient";
+import CreatureWiki from "@pages/CreatureWiki";
+import {
+  readJsonFile,
+  readOptionalJsonFile,
+  readOptionalTextFile,
+} from "@lib/wikiData";
+import {
+  getItemCodedName,
+  getItemDecodedName,
+  toSnakeCase,
+} from "@functions/utils";
+import { notFound } from "next/navigation";
+
+export const dynamic = "force-static";
+export const dynamicParams = true;
+
+const languageSet = new Set(supportedLanguages.map((lang) => lang.key));
+
+export async function generateStaticParams() {
+  return [];
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ lang: string; name: string }>;
+}) {
+  const { lang, name } = await params;
+
+  if (!languageSet.has(lang)) {
+    notFound();
+  }
+
+  const [creatures, translation, itemNames] = await Promise.all([
+    readJsonFile<Creature[]>("public/json/creatures_min.json"),
+    readJsonFile<Record<string, unknown>>(`public/locales/${lang}/translation.json`),
+    readOptionalJsonFile<Record<string, unknown>>(`public/locales/${lang}/items.json`),
+  ]);
+
+  const decodedName = getItemDecodedName(name);
+  const creature = creatures.find((cr) => cr.name.toLowerCase() === decodedName);
+
+  if (!creature) {
+    notFound();
+  }
+
+  const [creatureInfo, extraInfoContent] = await Promise.all([
+    readOptionalJsonFile<CreatureCompleteInfo>(
+      `public/json/creatures/${toSnakeCase(creature.name)}.json`,
+    ),
+    readOptionalTextFile(`wiki/creatures/${getItemCodedName(creature.name)}.md`),
+  ]);
+
+  const mergedInfo = creatureInfo
+    ? ({ ...creatureInfo, ...creature } satisfies CreatureCompleteInfo)
+    : undefined;
+
+  return (
+    <I18nProviderClient
+      lang={lang}
+      namespaces={{
+        translation,
+        items: itemNames ?? {},
+      }}
+    >
+      <CreatureWiki
+        initialCreature={creature}
+        initialCreatureInfo={mergedInfo}
+        extraInfoContent={extraInfoContent}
+        disableExternalFetches={true}
+      />
+    </I18nProviderClient>
+  );
+}

--- a/src/app/[lang]/item/[name]/[rarity]/page.tsx
+++ b/src/app/[lang]/item/[name]/[rarity]/page.tsx
@@ -1,0 +1,87 @@
+import { supportedLanguages } from "@config/languages";
+import type { Item, ItemCompleteInfo, Rarity } from "@ctypes/item";
+import I18nProviderClient from "@components/I18nProviderClient";
+import ItemWiki from "@pages/ItemWiki";
+import {
+  readJsonFile,
+  readOptionalJsonFile,
+  readOptionalTextFile,
+} from "@lib/wikiData";
+import {
+  getItemCodedName,
+  getItemDecodedName,
+  toSnakeCase,
+} from "@functions/utils";
+import { notFound } from "next/navigation";
+import { Rarity as RarityEnum } from "@ctypes/item";
+
+export const dynamic = "force-static";
+export const dynamicParams = true;
+
+const languageSet = new Set(supportedLanguages.map((lang) => lang.key));
+const rarities = Object.values(RarityEnum);
+
+export async function generateStaticParams() {
+  return [];
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ lang: string; name: string; rarity: string }>;
+}) {
+  const { lang, name, rarity } = await params;
+
+  if (!languageSet.has(lang)) {
+    notFound();
+  }
+
+  if (!rarities.includes(rarity as Rarity)) {
+    notFound();
+  }
+
+  const [items, translation, itemNames] = await Promise.all([
+    readJsonFile<Item[]>("public/json/items_min.json"),
+    readJsonFile<Record<string, unknown>>(
+      `public/locales/${lang}/translation.json`,
+    ),
+    readOptionalJsonFile<Record<string, unknown>>(
+      `public/locales/${lang}/items.json`,
+    ),
+  ]);
+
+  const decodedName = getItemDecodedName(name);
+  const item = items.find((it) => it.name.toLowerCase() === decodedName);
+
+  if (!item) {
+    notFound();
+  }
+
+  const [itemInfo, extraInfoContent] = await Promise.all([
+    readOptionalJsonFile<ItemCompleteInfo>(
+      `public/json/items/${toSnakeCase(item.name)}.json`,
+    ),
+    readOptionalTextFile(`wiki/items/${getItemCodedName(item.name)}.md`),
+  ]);
+
+  const mergedInfo = itemInfo
+    ? ({ ...itemInfo, ...item } satisfies ItemCompleteInfo)
+    : undefined;
+
+  return (
+    <I18nProviderClient
+      lang={lang}
+      namespaces={{
+        translation,
+        items: itemNames ?? {},
+      }}
+    >
+      <ItemWiki
+        initialItem={item}
+        initialItemInfo={mergedInfo}
+        extraInfoContent={extraInfoContent}
+        disableExternalFetches={true}
+      />
+    </I18nProviderClient>
+  );
+}

--- a/src/app/[lang]/item/[name]/page.tsx
+++ b/src/app/[lang]/item/[name]/page.tsx
@@ -1,0 +1,65 @@
+import { supportedLanguages } from "@config/languages";
+import type { Item, ItemCompleteInfo } from "@ctypes/item";
+import I18nProviderClient from "@components/I18nProviderClient";
+import ItemWiki from "@pages/ItemWiki";
+import { readJsonFile, readOptionalJsonFile, readOptionalTextFile } from "@lib/wikiData";
+import { getItemCodedName, getItemDecodedName, toSnakeCase } from "@functions/utils";
+import { notFound } from "next/navigation";
+
+export const dynamic = "force-static";
+export const dynamicParams = true;
+
+const languageSet = new Set(supportedLanguages.map((lang) => lang.key));
+
+export async function generateStaticParams() {
+  return [];
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ lang: string; name: string }>;
+}) {
+  const { lang, name } = await params;
+
+  if (!languageSet.has(lang)) {
+    notFound();
+  }
+
+  const [items, translation, itemNames] = await Promise.all([
+    readJsonFile<Item[]>("public/json/items_min.json"),
+    readJsonFile<Record<string, unknown>>(`public/locales/${lang}/translation.json`),
+    readOptionalJsonFile<Record<string, unknown>>(`public/locales/${lang}/items.json`),
+  ]);
+
+  const decodedName = getItemDecodedName(name);
+  const item = items.find((it) => it.name.toLowerCase() === decodedName);
+
+  if (!item) {
+    notFound();
+  }
+
+  const [itemInfo, extraInfoContent] = await Promise.all([
+    readOptionalJsonFile<ItemCompleteInfo>(`public/json/items/${toSnakeCase(item.name)}.json`),
+    readOptionalTextFile(`wiki/items/${getItemCodedName(item.name)}.md`),
+  ]);
+
+  const mergedInfo = itemInfo ? ({ ...itemInfo, ...item } satisfies ItemCompleteInfo) : undefined;
+
+  return (
+    <I18nProviderClient
+      lang={lang}
+      namespaces={{
+        translation,
+        items: itemNames ?? {},
+      }}
+    >
+      <ItemWiki
+        initialItem={item}
+        initialItemInfo={mergedInfo}
+        extraInfoContent={extraInfoContent}
+        disableExternalFetches={true}
+      />
+    </I18nProviderClient>
+  );
+}

--- a/src/app/[lang]/wiki/page.tsx
+++ b/src/app/[lang]/wiki/page.tsx
@@ -1,0 +1,42 @@
+import { supportedLanguages } from "@config/languages";
+import I18nProviderClient from "@components/I18nProviderClient";
+import Wiki from "@pages/Wiki";
+import { readJsonFile, readOptionalJsonFile } from "@lib/wikiData";
+import { notFound } from "next/navigation";
+
+export const dynamic = "force-static";
+
+const languageSet = new Set(supportedLanguages.map((lang) => lang.key));
+
+export async function generateStaticParams() {
+  return supportedLanguages.map((lang) => ({ lang: lang.key }));
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+
+  if (!languageSet.has(lang)) {
+    notFound();
+  }
+
+  const [translation, itemNames] = await Promise.all([
+    readJsonFile<Record<string, unknown>>(`public/locales/${lang}/translation.json`),
+    readOptionalJsonFile<Record<string, unknown>>(`public/locales/${lang}/items.json`),
+  ]);
+
+  return (
+    <I18nProviderClient
+      lang={lang}
+      namespaces={{
+        translation,
+        items: itemNames ?? {},
+      }}
+    >
+      <Wiki />
+    </I18nProviderClient>
+  );
+}

--- a/src/components/I18nProviderClient.tsx
+++ b/src/components/I18nProviderClient.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type React from "react";
+import { useMemo } from "react";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+import { createInstance } from "i18next";
+
+type I18nNamespaces = Record<string, Record<string, unknown>>;
+
+type I18nProviderClientProps = {
+  lang: string;
+  namespaces: I18nNamespaces;
+  children: React.ReactNode;
+};
+
+export default function I18nProviderClient({
+  lang,
+  namespaces,
+  children,
+}: I18nProviderClientProps) {
+  const i18n = useMemo(() => {
+    const instance = createInstance();
+    instance.use(initReactI18next).init(
+      {
+        lng: lang,
+        fallbackLng: "en",
+        resources: {
+          [lang]: namespaces,
+        },
+        ns: Object.keys(namespaces),
+        defaultNS: "translation",
+        interpolation: { escapeValue: false },
+        initImmediate: false,
+        react: { useSuspense: false },
+      } as never,
+    );
+    return instance;
+  }, [lang, namespaces]);
+
+  return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+}

--- a/src/components/Ingredient.tsx
+++ b/src/components/Ingredient.tsx
@@ -4,9 +4,10 @@ import { useTranslation } from "react-i18next";
 import { FaChevronUp, FaChevronDown } from "react-icons/fa";
 import Icon from "./Icon";
 import Ingredients from "./Ingredients";
-import { getItemUrl } from "@functions/utils";
+import { getItemPath } from "@functions/utils";
 import type { CustomItem } from "@ctypes";
 import { RarityTierEnum } from "@ctypes/item";
+import LanguageLink from "@components/LanguageLink";
 
 interface IngredientProps {
   ingredient: CustomItem;
@@ -20,7 +21,7 @@ const Ingredient: React.FC<IngredientProps> = memo(({ ingredient, value }) => {
   const hasIngredients =
     ingredient?.ingredients && ingredient?.ingredients.length > 0;
 
-  const url = getItemUrl(ingredient?.name);
+  const url = getItemPath(ingredient?.name);
 
   const getRarityColor = useCallback((value: RarityTierEnum) => {
     let color = "";
@@ -136,12 +137,12 @@ const Ingredient: React.FC<IngredientProps> = memo(({ ingredient, value }) => {
                   {Math.ceil(ingredient?.count * value)}×
                 </span>
               )}
-              <a
-                href={url}
+              <LanguageLink
+                to={url}
                 className="text-blue-400 hover:text-blue-300 transition-colors duration-200 font-medium"
               >
                 {t(ingredient?.name, { ns: "items" })}
-              </a>
+              </LanguageLink>
             </div>
             {ingredient?.category && (
               <div className="text-sm text-gray-400 mt-1">

--- a/src/components/Wiki/CreatureDropsInfo.tsx
+++ b/src/components/Wiki/CreatureDropsInfo.tsx
@@ -2,7 +2,7 @@ import type React from "react";
 import { useTranslation } from "react-i18next";
 import LanguageLink from "@components/LanguageLink";
 import type { Drop } from "@ctypes/item";
-import { getItemUrl } from "@functions/utils";
+import { getItemPath } from "@functions/utils";
 
 interface CreatureDropsInfoProps {
   drops?: Drop[];
@@ -21,7 +21,7 @@ const CreatureDropsInfo: React.FC<CreatureDropsInfoProps> = ({
       const dropKey = `${drop.name}-${drop.tier ?? "no-tier"}-${drop.minQuantity ?? "no-min"}-${drop.maxQuantity ?? "no-max"}-${drop.chance ?? "no-chance"}`;
       return (
         <li className="inline-block mr-2 mb-2" key={dropKey} title={titleInfo}>
-          <LanguageLink to={getItemUrl(drop.name)}>
+          <LanguageLink to={getItemPath(drop.name)}>
             <div className="p-2 bg-gray-800 border border-gray-700 hover:border-blue-500 rounded-lg text-neutral-300 transition-all duration-300 hover:shadow-lg hover:transform hover:scale-102">
               {t(drop.name)} {drop?.tier && `(${drop.tier})`}
             </div>

--- a/src/components/Wiki/ExtraInfo.tsx
+++ b/src/components/Wiki/ExtraInfo.tsx
@@ -9,9 +9,15 @@ interface ExtraInfoProps {
   type: "items" | "creatures";
   name: string;
   content?: string;
+  disableFetch?: boolean;
 }
 
-const ExtraInfo: React.FC<ExtraInfoProps> = ({ type, name, content }) => {
+const ExtraInfo: React.FC<ExtraInfoProps> = ({
+  type,
+  name,
+  content,
+  disableFetch,
+}) => {
   const [loadedContent, setLoadedContent] = useState<string>(content ?? "");
   const [error, setError] = useState<boolean>(false);
 
@@ -21,6 +27,10 @@ const ExtraInfo: React.FC<ExtraInfoProps> = ({ type, name, content }) => {
   useEffect(() => {
     if (content) {
       setLoadedContent(content);
+      return;
+    }
+
+    if (disableFetch) {
       return;
     }
 

--- a/src/components/Wiki/RelatedCreatures.tsx
+++ b/src/components/Wiki/RelatedCreatures.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import { useTranslation } from "react-i18next";
 import LanguageLink from "@components/LanguageLink";
-import { getCreatureUrl } from "@functions/utils";
+import { getCreaturePath } from "@functions/utils";
 
 interface RelatedCreaturesProps {
   related?: string[];
@@ -16,7 +16,7 @@ const RelatedCreatures: React.FC<RelatedCreaturesProps> = ({
     return related?.map((related) => {
       return (
         <li className="inline-block mr-2 mb-2" key={related} title={related}>
-          <LanguageLink to={getCreatureUrl(related)}>
+          <LanguageLink to={getCreaturePath(related)}>
             <div className="p-2 bg-gray-800 border border-gray-700 hover:border-blue-500 rounded-lg text-neutral-300 transition-all duration-300 hover:shadow-lg hover:transform hover:scale-102">
               {related}
             </div>

--- a/src/components/Wiki/SchematicDropInfo.tsx
+++ b/src/components/Wiki/SchematicDropInfo.tsx
@@ -2,8 +2,9 @@ import type React from "react";
 import { useTranslation } from "react-i18next";
 import { memo, useMemo } from "react";
 import Icon from "../Icon";
-import { getItemUrl } from "@functions/utils";
+import { getItemPath } from "@functions/utils";
 import type { ItemCompleteInfo } from "@ctypes/item";
+import LanguageLink from "@components/LanguageLink";
 
 interface SchematicDropInfoProps {
   item: ItemCompleteInfo;
@@ -14,15 +15,15 @@ const SchematicDropInfo: React.FC<SchematicDropInfoProps> = ({ item }) => {
 
   const itemList = useMemo(() => {
     return item.learn?.map((schematic) => {
-      const url = getItemUrl(schematic);
+      const url = getItemPath(schematic);
 
       return (
         <li className="inline-block mr-2 mb-2" key={`schematic-${schematic}`}>
           <div className="p-2 bg-gray-800 border border-gray-700 rounded-lg flex items-center space-x-2">
             <Icon key={schematic} name={schematic} />
-            <a href={url} className="text-blue-400 hover:text-blue-300">
+            <LanguageLink to={url} className="text-blue-400 hover:text-blue-300">
               {t(schematic, { ns: "items" })}
-            </a>
+            </LanguageLink>
           </div>
         </li>
       );

--- a/src/components/Wiki/SchematicItems.tsx
+++ b/src/components/Wiki/SchematicItems.tsx
@@ -1,8 +1,9 @@
 import type React from "react";
 import { useTranslation } from "react-i18next";
 import Icon from "../Icon";
-import { getItemUrl } from "@functions/utils";
+import { getItemPath } from "@functions/utils";
 import type { ItemCompleteInfo } from "@ctypes/item";
+import LanguageLink from "@components/LanguageLink";
 
 interface SchematicItemsProps {
   item: ItemCompleteInfo;
@@ -13,15 +14,15 @@ const SchematicItems: React.FC<SchematicItemsProps> = ({ item }) => {
 
   const showSchematicItems = () => {
     return item?.learn?.map((itemCraft: string) => {
-      const url = getItemUrl(itemCraft);
+      const url = getItemPath(itemCraft);
 
       return (
         <li className="inline-block mr-2 mb-2" key={itemCraft}>
           <div className="p-2 bg-gray-800 border border-gray-700 rounded-lg flex items-center space-x-2">
             <Icon key={itemCraft} name={itemCraft} />
-            <a href={url} className="text-blue-400 hover:text-blue-300">
+            <LanguageLink to={url} className="text-blue-400 hover:text-blue-300">
               {t(itemCraft)}
-            </a>
+            </LanguageLink>
           </div>
         </li>
       );

--- a/src/components/Wiki/WikiContent.tsx
+++ b/src/components/Wiki/WikiContent.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import LanguageLink from "@components/LanguageLink";
 import Ingredient from "@components/Ingredient";
 import Icon from "@components/Icon";
-import { getCreatureUrl } from "@functions/utils";
+import { getCreaturePath } from "@functions/utils";
 import type { Item } from "@ctypes/item";
 import type { Creature } from "@ctypes/creature";
 import type { Perk } from "@ctypes/perk";
@@ -67,7 +67,7 @@ const WikiContent = ({
           data-testid="wiki-creature"
         >
           <LanguageLink
-            to={getCreatureUrl(creature.name)}
+            to={getCreaturePath(creature.name)}
             aria-label={t(creature.name, { ns: "creatures" })}
           >
             <div className="bg-gray-800 border border-gray-700 hover:border-blue-500 rounded-lg overflow-hidden shadow-md transition-all duration-300 hover:shadow-lg hover:transform hover:scale-102">

--- a/src/components/Wiki/WikiDescription.tsx
+++ b/src/components/Wiki/WikiDescription.tsx
@@ -5,13 +5,25 @@ import { getExternalWikiDescription } from "@functions/requests/other";
 
 interface WikiDescriptionProps {
   name: string;
+  description?: string;
+  disableFetch?: boolean;
 }
 
-const WikiDescription: React.FC<WikiDescriptionProps> = ({ name }) => {
-  const [description, setDescription] = useState<string>();
+const WikiDescription: React.FC<WikiDescriptionProps> = ({
+  name,
+  description: initialDescription,
+  disableFetch,
+}) => {
+  const [description, setDescription] = useState<string | undefined>(
+    initialDescription,
+  );
   const { t } = useTranslation();
 
   useEffect(() => {
+    if (disableFetch || initialDescription) {
+      return;
+    }
+
     const updateDescription = async () => {
       try {
         const detail = await getExternalWikiDescription(name);
@@ -24,7 +36,7 @@ const WikiDescription: React.FC<WikiDescriptionProps> = ({ name }) => {
     };
 
     updateDescription();
-  }, [name]);
+  }, [name, disableFetch, initialDescription]);
 
   const wikiUrl = useMemo(() => {
     return `https://lastoasis.fandom.com/wiki/Special:Search?query=${encodeURIComponent(name)}&scope=internal&navigationSearch=true`;

--- a/src/functions/utils.ts
+++ b/src/functions/utils.ts
@@ -22,6 +22,23 @@ export const getItemCodedName = (itemName: string) =>
 export const getItemDecodedName = (itemName: string) =>
   decodeURI(String(itemName)).replaceAll("_", " ").toLowerCase().trim();
 
+export const getItemPath = (itemName?: string, rarity?: Rarity) => {
+  if (!itemName) {
+    return "/item";
+  }
+
+  const rarityPath = rarity ? `/${rarity}` : "";
+  return `/item/${encodeURI(getItemCodedName(itemName))}${rarityPath}`;
+};
+
+export const getCreaturePath = (creatureName?: string) => {
+  if (!creatureName) {
+    return "/creature";
+  }
+
+  return `/creature/${encodeURI(getItemCodedName(creatureName))}`;
+};
+
 const getValidLangPrefix = (): string => {
   const pathname =
     typeof globalThis !== "undefined" && "location" in globalThis
@@ -36,13 +53,12 @@ const getValidLangPrefix = (): string => {
 
 export const getItemUrl = (itemName: string, rarity?: Rarity) => {
   const langPrefix = getValidLangPrefix();
-  const rarityPath = rarity ? `/${rarity}` : "";
-  return `${langPrefix}/item/${encodeURI(getItemCodedName(itemName))}${rarityPath}`;
+  return `${langPrefix}${getItemPath(itemName, rarity)}`;
 };
 
 export const getCreatureUrl = (creatureName: string) => {
   const langPrefix = getValidLangPrefix();
-  return `${langPrefix}/creature/${encodeURI(getItemCodedName(creatureName))}`;
+  return `${langPrefix}${getCreaturePath(creatureName)}`;
 };
 
 export const getItemCraftUrl = (itemName: string) =>

--- a/src/legacy-pages/CreatureWiki.tsx
+++ b/src/legacy-pages/CreatureWiki.tsx
@@ -5,12 +5,11 @@ import { useTranslation } from "react-i18next";
 import { useParams, useRouter } from "next/navigation";
 import Icon from "@components/Icon";
 import LoadingScreen from "@components/LoadingScreen";
-import Comments from "@components/Wiki/Comments";
 import {
   getDomain,
   getItemDecodedName,
-  getCreatureUrl,
-  getItemUrl,
+  getCreaturePath,
+  getItemPath,
   toSnakeCase,
 } from "@functions/utils";
 import HeaderMeta, { OpenGraphType } from "@components/HeaderMeta";
@@ -19,6 +18,11 @@ import CreatureDropsInfo from "@components/Wiki/CreatureDropsInfo";
 import ExtraInfo from "@components/Wiki/ExtraInfo";
 import RelatedCreatures from "@components/Wiki/RelatedCreatures";
 import { useLanguagePrefix } from "@hooks/useLanguagePrefix";
+import dynamic from "next/dynamic";
+
+const Comments = dynamic(() => import("@components/Wiki/Comments"), {
+  ssr: false,
+});
 
 const WikiDescription = React.lazy(
   () => import("@components/Wiki/WikiDescription"),
@@ -28,12 +32,14 @@ type CreatureWikiProps = {
   initialCreature?: Creature;
   initialCreatureInfo?: CreatureCompleteInfo;
   extraInfoContent?: string;
+  disableExternalFetches?: boolean;
 };
 
 const CreatureWiki: React.FC<CreatureWikiProps> = ({
   initialCreature,
   initialCreatureInfo,
   extraInfoContent,
+  disableExternalFetches,
 }) => {
   const { t, i18n } = useTranslation();
   const router = useRouter();
@@ -107,7 +113,9 @@ const CreatureWiki: React.FC<CreatureWikiProps> = ({
   const creatureName =
     creature?.name ?? creatureInfo?.name ?? getItemDecodedName(name ?? "");
   const domain = getDomain();
-  const canonical = `${domain}${getCreatureUrl(creatureName)}`;
+  const canonical = `${domain}${getLanguagePrefixedPath(
+    getCreaturePath(creatureName),
+  )}`;
   const creatureDescription = `Drops, stats and locations for ${creatureName} in Last Oasis.`;
   const creatureStructuredData = useMemo(() => {
     const additionalProperty: Array<Record<string, unknown>> = [];
@@ -157,7 +165,9 @@ const CreatureWiki: React.FC<CreatureWikiProps> = ({
       mentions.push({
         "@type": "Thing",
         name: relatedCreature,
-        url: `${domain}${getCreatureUrl(relatedCreature)}`,
+        url: `${domain}${getLanguagePrefixedPath(
+          getCreaturePath(relatedCreature),
+        )}`,
       });
     }
 
@@ -165,7 +175,7 @@ const CreatureWiki: React.FC<CreatureWikiProps> = ({
       mentions.push({
         "@type": "Thing",
         name: creatureDrop.name,
-        url: `${domain}${getItemUrl(creatureDrop.name)}`,
+        url: `${domain}${getLanguagePrefixedPath(getItemPath(creatureDrop.name))}`,
       });
     }
 
@@ -179,7 +189,7 @@ const CreatureWiki: React.FC<CreatureWikiProps> = ({
       isPartOf: {
         "@type": "CollectionPage",
         name: t("seo.wiki.title"),
-        url: `${domain}/wiki`,
+        url: `${domain}${getLanguagePrefixedPath("/wiki")}`,
       },
     };
 
@@ -200,6 +210,7 @@ const CreatureWiki: React.FC<CreatureWikiProps> = ({
     domain,
     i18n.language,
     t,
+    getLanguagePrefixedPath,
   ]);
 
   useEffect(() => {
@@ -305,10 +316,15 @@ const CreatureWiki: React.FC<CreatureWikiProps> = ({
             type="creatures"
             name={creatureName}
             content={extraInfoContent}
+            disableFetch={disableExternalFetches}
           />
         </Suspense>
         <Suspense fallback={loadingCreaturePart()}>
-          <WikiDescription key="wikidescription" name={creatureName} />
+          <WikiDescription
+            key="wikidescription"
+            name={creatureName}
+            disableFetch={disableExternalFetches}
+          />
         </Suspense>
         <Suspense fallback={loadingCreaturePart()}>
           <Comments key="comments" name={creatureName} />

--- a/src/legacy-pages/ItemWiki.tsx
+++ b/src/legacy-pages/ItemWiki.tsx
@@ -17,14 +17,13 @@ import LoadingScreen from "@components/LoadingScreen";
 import ModuleInfo from "@components/Wiki/ModuleInfo";
 import ToolInfo from "@components/Wiki/ToolInfo";
 import GenericInfo from "@components/Wiki/GenericInfo";
-import Comments from "@components/Wiki/Comments";
 import WalkerUpgrades from "@components/Wiki/WalkerUpgrades";
 import RigSlotsInfo from "@components/Wiki/RigSlotsInfo";
 import { calcRarityUpgradePrice, calcRarityValue } from "@functions/rarityCalc";
 import {
-  getCreatureUrl,
   getDomain,
-  getItemUrl,
+  getCreaturePath,
+  getItemPath,
   getItemCraftUrl,
   getItemDecodedName,
   toSnakeCase,
@@ -35,6 +34,11 @@ import { FaTools, FaExclamationTriangle } from "react-icons/fa";
 import ExtraInfo from "@components/Wiki/ExtraInfo";
 import ReportIncidentModal from "@components/ReportIncidentModal";
 import { useLanguagePrefix } from "@hooks/useLanguagePrefix";
+import dynamic from "next/dynamic";
+
+const Comments = dynamic(() => import("@components/Wiki/Comments"), {
+  ssr: false,
+});
 
 const WikiDescription = React.lazy(
   () => import("@components/Wiki/WikiDescription"),
@@ -56,13 +60,17 @@ const CreatureDropsInfo = React.lazy(
 type ItemWikiProps = {
   initialItem?: Item;
   initialItemInfo?: ItemCompleteInfo;
+  initialAllItems?: Item[];
   extraInfoContent?: string;
+  disableExternalFetches?: boolean;
 };
 
 const ItemWiki: React.FC<ItemWikiProps> = ({
   initialItem,
   initialItemInfo,
+  initialAllItems,
   extraInfoContent,
+  disableExternalFetches,
 }) => {
   const { t, i18n } = useTranslation();
   const router = useRouter();
@@ -79,7 +87,7 @@ const ItemWiki: React.FC<ItemWikiProps> = ({
   const [isLoaded, setIsLoaded] = useState<boolean>(
     Boolean(initialItem || initialItemInfo),
   );
-  const [allItems, setAllItems] = useState<Item[]>([]);
+  const [allItems, setAllItems] = useState<Item[]>(initialAllItems ?? []);
   const [textColor, setTextColor] = useState<string>("text-gray-400");
   const [isReportModalOpen, setIsReportModalOpen] = useState<boolean>(false);
 
@@ -209,7 +217,7 @@ const ItemWiki: React.FC<ItemWikiProps> = ({
   const updateRarity = useCallback(
     (value: Rarity) => {
       if (name) {
-        router.push(getLanguagePrefixedPath(getItemUrl(name, value)));
+        router.push(getLanguagePrefixedPath(getItemPath(name, value)));
       }
     },
     [name, router, getLanguagePrefixedPath],
@@ -271,10 +279,13 @@ const ItemWiki: React.FC<ItemWikiProps> = ({
   const itemName =
     item?.name ?? itemInfo?.name ?? getItemDecodedName(name ?? "");
   const domain = getDomain();
-  const canonical = `${domain}${getItemUrl(itemName, rarity)}`;
+  const canonical = `${domain}${getLanguagePrefixedPath(
+    getItemPath(itemName, rarity),
+  )}`;
   const itemDescription = `Crafting, stats and usages for ${itemName} in Last Oasis.`;
   const category = itemInfo?.category ?? item?.category;
-  const parentUrl = itemInfo?.parent && getItemUrl(itemInfo.parent);
+  const parentUrl =
+    itemInfo?.parent && getLanguagePrefixedPath(getItemPath(itemInfo.parent));
   const craftUrl = getItemCraftUrl(name ?? itemName);
 
   const itemStructuredData = useMemo(() => {
@@ -349,7 +360,7 @@ const ItemWiki: React.FC<ItemWikiProps> = ({
       mentions.push({
         "@type": "Thing",
         name: itemDrop.name,
-        url: `${domain}${getItemUrl(itemDrop.name)}`,
+        url: `${domain}${getLanguagePrefixedPath(getItemPath(itemDrop.name))}`,
       });
     }
 
@@ -357,7 +368,9 @@ const ItemWiki: React.FC<ItemWikiProps> = ({
       mentions.push({
         "@type": "Thing",
         name: droppedBy.name,
-        url: `${domain}${getCreatureUrl(droppedBy.name)}`,
+        url: `${domain}${getLanguagePrefixedPath(
+          getCreaturePath(droppedBy.name),
+        )}`,
       });
     }
 
@@ -365,7 +378,7 @@ const ItemWiki: React.FC<ItemWikiProps> = ({
       mentions.push({
         "@type": "Thing",
         name: relatedLearn,
-        url: `${domain}${getItemUrl(relatedLearn)}`,
+        url: `${domain}${getLanguagePrefixedPath(getItemPath(relatedLearn))}`,
       });
     }
 
@@ -387,7 +400,7 @@ const ItemWiki: React.FC<ItemWikiProps> = ({
       data.isPartOf = {
         "@type": "DefinedTerm",
         name: itemInfo.parent,
-        url: `${domain}${getItemUrl(itemInfo.parent)}`,
+        url: `${domain}${getLanguagePrefixedPath(getItemPath(itemInfo.parent))}`,
       };
     }
 
@@ -404,6 +417,7 @@ const ItemWiki: React.FC<ItemWikiProps> = ({
     itemDescription,
     itemInfo,
     itemName,
+    getLanguagePrefixedPath,
   ]);
 
   useEffect(() => {
@@ -717,7 +731,11 @@ const ItemWiki: React.FC<ItemWikiProps> = ({
           )}
         </Suspense>
         <Suspense fallback={loadingItemPart()}>
-          <WikiDescription key="wikidescription" name={itemName} />
+          <WikiDescription
+            key="wikidescription"
+            name={itemName}
+            disableFetch={disableExternalFetches}
+          />
         </Suspense>
         <Suspense fallback={loadingItemPart()}>
           <CanBeUsedInfo key="CanBeUsedInfo" name={itemName} items={allItems} />
@@ -733,7 +751,12 @@ const ItemWiki: React.FC<ItemWikiProps> = ({
           )}
         </Suspense>
         <Suspense fallback={loadingItemPart()}>
-          <ExtraInfo type="items" name={itemName} content={extraInfoContent} />
+          <ExtraInfo
+            type="items"
+            name={itemName}
+            content={extraInfoContent}
+            disableFetch={disableExternalFetches}
+          />
         </Suspense>
         <Suspense fallback={loadingItemPart()}>
           <Comments key="comments" name={itemName} />

--- a/src/legacy-pages/Wiki.tsx
+++ b/src/legacy-pages/Wiki.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next";
 import queryString from "query-string";
 import { getWikiLastUpdate } from "@functions/github";
 import { AnalyticsEvent, sendEvent } from "@functions/page-tracking";
-import { getCreatureUrl, getDomain, getItemUrl } from "@functions/utils";
+import { getCreaturePath, getDomain, getItemPath } from "@functions/utils";
 import HeaderMeta from "@components/HeaderMeta";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { Item } from "@ctypes/item";
@@ -41,7 +41,7 @@ const Wiki: React.FC<WikiProps> = ({
   const { getLanguagePrefixedPath } = useLanguagePrefix();
   const { t, i18n } = useTranslation();
   const domain = getDomain();
-  const wikiCanonical = `${domain}/wiki`;
+  const wikiCanonical = `${domain}${getLanguagePrefixedPath("/wiki")}`;
   const wikiDescription = t("seo.wiki.description");
   const [contentType, setContentType] = useState<WikiContentType>("items");
   const [wikiLastUpdate, setWikiLastUpdate] = useState<string | undefined>(
@@ -457,7 +457,9 @@ const Wiki: React.FC<WikiProps> = ({
           item: {
             "@type": "DefinedTerm",
             name: currentItem.name,
-            url: `${domain}${getItemUrl(currentItem.name)}`,
+            url: `${domain}${getLanguagePrefixedPath(
+              getItemPath(currentItem.name),
+            )}`,
           },
         });
       }
@@ -468,7 +470,9 @@ const Wiki: React.FC<WikiProps> = ({
           item: {
             "@type": "Thing",
             name: currentCreature.name,
-            url: `${domain}${getCreatureUrl(currentCreature.name)}`,
+            url: `${domain}${getLanguagePrefixedPath(
+              getCreaturePath(currentCreature.name),
+            )}`,
           },
         });
       }
@@ -525,6 +529,7 @@ const Wiki: React.FC<WikiProps> = ({
     domain,
     i18n.language,
     t,
+    getLanguagePrefixedPath,
     wikiCanonical,
     wikiDescription,
   ]);

--- a/src/lib/wikiData.ts
+++ b/src/lib/wikiData.ts
@@ -1,11 +1,62 @@
+import "server-only";
+
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { headers } from "next/headers";
+import { cache } from "react";
 
 const projectRoot = process.cwd();
 
+function toPublicUrlPath(relativePath: string) {
+  if (!relativePath.startsWith("public/")) return null;
+  return `/${relativePath.slice("public/".length)}`;
+}
+
+async function getBaseUrlFromRequest() {
+  const h = await headers();
+  const host = h.get("x-forwarded-host") ?? h.get("host");
+  if (!host) return null;
+  const proto = h.get("x-forwarded-proto") ?? "https";
+  return `${proto}://${host}`;
+}
+
+async function getBaseUrl() {
+  if (process.env.NEXT_PUBLIC_SITE_URL) {
+    return process.env.NEXT_PUBLIC_SITE_URL.replace(/\/+$/, "");
+  }
+
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+
+  return await getBaseUrlFromRequest();
+}
+
+async function readPublicTextViaHttp(relativePath: string): Promise<string> {
+  const urlPath = toPublicUrlPath(relativePath);
+  const baseUrl = await getBaseUrl();
+  if (!urlPath || !baseUrl) {
+    throw new Error(`Cannot resolve public URL for "${relativePath}"`);
+  }
+
+  const res = await fetch(`${baseUrl}${urlPath}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch "${urlPath}" (${res.status})`);
+  }
+  return await res.text();
+}
+
+const readTextFile = cache(async (relativePath: string): Promise<string> => {
+  try {
+    const absolutePath = path.join(projectRoot, relativePath);
+    return await readFile(absolutePath, "utf8");
+  } catch {
+    return await readPublicTextViaHttp(relativePath);
+  }
+});
+
 export async function readJsonFile<T>(relativePath: string): Promise<T> {
-  const absolutePath = path.join(projectRoot, relativePath);
-  const raw = await readFile(absolutePath, "utf8");
+  const raw = await readTextFile(relativePath);
   return JSON.parse(raw) as T;
 }
 
@@ -13,8 +64,7 @@ export async function readOptionalTextFile(
   relativePath: string,
 ): Promise<string | undefined> {
   try {
-    const absolutePath = path.join(projectRoot, relativePath);
-    return await readFile(absolutePath, "utf8");
+    return await readTextFile(relativePath);
   } catch {
     return undefined;
   }

--- a/src/lib/wikiData.ts
+++ b/src/lib/wikiData.ts
@@ -20,3 +20,15 @@ export async function readOptionalTextFile(
   }
 }
 
+export async function readOptionalJsonFile<T>(
+  relativePath: string,
+): Promise<T | undefined> {
+  const text = await readOptionalTextFile(relativePath);
+  if (!text) return undefined;
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,6 +28,15 @@ export function middleware(req: NextRequest) {
 
   if (first && languageSet.has(first)) {
     const restSegments = segments.slice(1);
+
+    if (
+      restSegments[0] === "wiki" ||
+      restSegments[0] === "item" ||
+      restSegments[0] === "creature"
+    ) {
+      return NextResponse.next();
+    }
+
     const url = req.nextUrl.clone();
     url.pathname = `/${restSegments.join("/")}`;
     url.search = search;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,9 @@
       ],
       "@hooks/*": [
         "src/hooks/*"
+      ],
+      "@lib/*": [
+        "src/lib/*"
       ]
     },
     "noUnusedLocals": true,


### PR DESCRIPTION
## Summary by Sourcery

Introduce statically-generated, language-aware wiki item and creature pages (including per-rarity item routes), and update legacy wiki components and utilities to support the new routing and data-loading model.

New Features:
- Add Next.js app router pages for language-scoped wiki index, items (including per-rarity variants), and creatures that hydrate existing legacy wiki views with pre-fetched JSON/markdown content.
- Introduce a client-side i18n provider component to initialize and supply i18next resources for the new app router pages.
- Extend sitemap generation to include per-rarity item URLs for all items.

Enhancements:
- Refine item and creature URL/path helpers and migrate wiki links and structured data to use language-prefixed paths consistently.
- Allow wiki description and extra info components to accept initial content and optionally skip external fetches, enabling build-time rendering without outbound requests.
- Ensure wiki-related middleware and canonical URLs correctly respect language prefixes for wiki, item, and creature routes.

Build:
- Extend TypeScript path aliases to cover the shared wiki data utilities used by build-time and runtime code.

Chores:
- Add a helper for reading optional JSON files used when loading pre-generated wiki data.