### PR TITLE
🎨 Palette: Improve custom select keyboard focus and restoration

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+# Palette's Journal - Critical UX & Accessibility Learnings
+
+This journal documents critical UX and accessibility insights discovered during design and development.
+
+## 2025-07-16 - Custom Select Box Keyboard Accessibility and Focus Restoration
+**Learning:** Custom dropdown/select boxes often suffer from poor accessibility because focus remains trapped on the trigger button or is lost when selecting/dismissing options. Auto-focusing the search text input upon opening, allowing arrow key navigation to jump directly to options, and restoring focus to the trigger button upon select or Escape press creates an incredibly fluid and keyboard-friendly user experience that perfectly aligns with WAI-ARIA practices.
+**Action:** Always implement robust focus trap/restoration and arrow-key/Escape key listener bindings when designing custom components that emulate native select/dropdown menus.

--- a/playwright/e2e/trades.spec.ts
+++ b/playwright/e2e/trades.spec.ts
@@ -210,4 +210,52 @@ test.describe("Trades Page", () => {
     // Assert the payload of the POST request
     expect(postRequestPayload).not.toBeNull();
   });
+
+  test("should handle keyboard accessibility on resource-type searchable select", async ({
+    page,
+  }) => {
+    await page.route("**/users", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          discordtag: "testUser#1234",
+          nickname: "TestNickname",
+        }),
+      });
+    });
+
+    await page.evaluate(() => {
+      localStorage.setItem("token", "fake-user-token");
+      localStorage.setItem("discordid", "fake-discord-id");
+    });
+
+    await page.route("**/items_min.json", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          { name: "Aloe Vera", category: "Resource" },
+          { name: "Wood", category: "Resource" },
+        ]),
+      });
+    });
+
+    await page.reload();
+
+    const selectButton = page.getByTestId("resource-type");
+    await expect(selectButton).toBeVisible();
+
+    // Trigger button should open the searchable select on click
+    await selectButton.click();
+
+    // Dropdown search input should automatically receive focus
+    const searchInput = page.locator("#resourcetype-options input");
+    await expect(searchInput).toBeFocused();
+
+    // Pressing Escape should close the dropdown and return focus to the trigger button
+    await page.keyboard.press("Escape");
+    await expect(searchInput).not.toBeVisible();
+    await expect(selectButton).toBeFocused();
+  });
 });

--- a/src/components/SearchableSelect.tsx
+++ b/src/components/SearchableSelect.tsx
@@ -27,6 +27,8 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
   const [searchText, setSearchText] = useState("");
   const [filteredOptions, setFilteredOptions] = useState(options);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (searchText.trim() === "") {
@@ -55,6 +57,13 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
     };
   }, []);
 
+  // Auto-focus input on open
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isOpen]);
+
   const selectedLabel =
     options.find((option) => option.value === value)?.label ?? "";
 
@@ -62,11 +71,31 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
     onChange(optionValue);
     setIsOpen(false);
     setSearchText("");
+    buttonRef.current?.focus();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      setIsOpen(false);
+      buttonRef.current?.focus();
+    }
+  };
+
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      const selectEl = document.getElementById(`${id}-select`);
+      if (selectEl) {
+        (selectEl as HTMLSelectElement).focus();
+      }
+    }
   };
 
   return (
-    <div className="relative" ref={wrapperRef}>
+    // biome-ignore lint/a11y/noStaticElementInteractions: Keyboard container handler is required for custom select accessibility
+    <div className="relative" ref={wrapperRef} onKeyDown={handleKeyDown}>
       <button
+        ref={buttonRef}
         type="button"
         className={`w-full p-2 bg-gray-700 border border-gray-600 rounded-lg text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer flex justify-between items-center ${className}`}
         onClick={() => setIsOpen(!isOpen)}
@@ -87,6 +116,7 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
         >
           <div className="p-2 sticky top-0 bg-gray-700 border-b border-gray-600">
             <input
+              ref={inputRef}
               id={id}
               type="text"
               className="w-full p-2 bg-gray-800 border border-gray-600 rounded-lg text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -94,6 +124,7 @@ const SearchableSelect: React.FC<SearchableSelectProps> = ({
               value={searchText}
               onChange={(e) => setSearchText(e.target.value)}
               onClick={(e) => e.stopPropagation()}
+              onKeyDown={handleInputKeyDown}
               aria-label={t("common.search")}
             />
           </div>

--- a/src/pages/Crafter.tsx
+++ b/src/pages/Crafter.tsx
@@ -362,7 +362,7 @@ const Crafter: React.FC = () => {
             value={searchText}
           />
           <button
-            className="ml-3 p-2 text-gray-300 hover:text-white focus:outline-none bg-transparent"
+            className="ml-3 p-2 text-gray-300 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-lg bg-transparent"
             type="button"
             onClick={toggleReportModal}
             aria-label={t("crafter.reportBug")}
@@ -371,7 +371,7 @@ const Crafter: React.FC = () => {
             <FaExclamationTriangle className="fa-lg" />
           </button>
           <button
-            className="lg:hidden ml-3 p-2 text-gray-300 hover:text-white focus:outline-none"
+            className="lg:hidden ml-3 p-2 text-gray-300 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-lg"
             type="button"
             onClick={toggleItemsNav}
             aria-controls="items-nav"


### PR DESCRIPTION
This change implements a high-impact accessibility and keyboard navigation micro-UX improvement for the SearchableSelect custom dropdown component, ensuring screen reader and keyboard users can navigate seamlessly. Additionally, it addresses focus outlines on icon-only buttons on the Crafter page.

---
*PR created automatically by Jules for task [5796177887630767273](https://jules.google.com/task/5796177887630767273) started by @dm94*

## Summary by Sourcery

Improve keyboard accessibility and focus management for the custom SearchableSelect dropdown and related UI controls.

New Features:
- Enable automatic focusing of the SearchableSelect search input when the dropdown opens.
- Support keyboard navigation from the SearchableSelect search input to the options list using the ArrowDown key.
- Restore focus to the SearchableSelect trigger button when an option is selected or the dropdown is dismissed with Escape.

Enhancements:
- Add Escape-key handling on the SearchableSelect container to close the dropdown and return focus to the trigger button.
- Refine focus-visible styles for icon-only buttons on the Crafter page to provide clearer keyboard focus indication.
- Add an accessibility-focused Playwright test covering keyboard interaction with the resource-type searchable select.

Documentation:
- Introduce Palette accessibility journal entry documenting best practices for custom select keyboard accessibility and focus restoration.

Tests:
- Add an end-to-end test validating keyboard focus behavior of the resource-type SearchableSelect on the Trades page.