### PR TITLE
🎨 Palette: Keyboard shortcut and visual cue to focus Wiki search input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - Keyboard shortcut helper for global search and navigation
+**Learning:** Users on content-heavy wikis highly appreciate quick, keyboard-driven navigation to search filters and inputs. Adding a standard shortcut key like `/` to focus search bars drastically lowers interaction friction, especially when accompanied by a subtle, screen-reader-friendly keyboard hint.
+**Action:** Implement `/` keyboard shortcut key to focus the input field in the wiki search component and render a visual `[/]` helper next to or inside the search field. Ensure the shortcut is suppressed when focusing on other input or editing controls to avoid conflict.

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,17 @@
+
+> stiletto-web@5.58.0 dev /app
+> vite
+
+
+  VITE v8.0.16  ready in 302 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose
+6:53:03 AM [vite] (client) hmr update /src/styles/style.css, /src/components/Wiki/SearchBar.tsx
+6:53:34 AM [vite] (client) hmr update /src/styles/style.css, /src/components/Wiki/SearchBar.tsx
+6:54:14 AM [vite] (client) hmr update /src/styles/style.css, /src/components/Wiki/SearchBar.tsx
+6:55:06 AM [vite] (client) hmr update /src/styles/style.css
+6:55:06 AM [vite] (client) hmr update /src/styles/style.css
+6:55:06 AM [vite] (client) hmr update /src/styles/style.css
+6:55:06 AM [vite] (client) hmr update /src/styles/style.css
+ ELIFECYCLE  Command failed with exit code 143.

--- a/public/sitemap-creatures.xml
+++ b/public/sitemap-creatures.xml
@@ -14,7 +14,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ac_relic_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ac_relic_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ac_relic_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -32,7 +32,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ac_relic_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ac_relic_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ac_relic_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -50,7 +50,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/altar_of_the_dawn" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/altar_of_the_dawn" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/altar_of_the_dawn" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -68,7 +68,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/altar_of_the_dusk" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/altar_of_the_dusk" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/altar_of_the_dusk" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -86,7 +86,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ammo_box_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ammo_box_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ammo_box_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -104,7 +104,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ammo_box_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ammo_box_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ammo_box_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -122,7 +122,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ammo_box_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ammo_box_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ammo_box_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -140,7 +140,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ammo_box_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ammo_box_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ammo_box_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -158,7 +158,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ancient_pyramid" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ancient_pyramid" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ancient_pyramid" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -176,7 +176,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ancient_towers_loot_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ancient_towers_loot_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ancient_towers_loot_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -194,7 +194,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ash_hills_watchtower" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ash_hills_watchtower" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ash_hills_watchtower" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -212,7 +212,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ash_oracle_fortress" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ash_oracle_fortress" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ash_oracle_fortress" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -230,7 +230,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/asteroid_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/asteroid_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/asteroid_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -248,7 +248,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/asteroid_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/asteroid_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/asteroid_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -266,7 +266,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/asteroid_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/asteroid_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/asteroid_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -284,7 +284,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/asteroid_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/asteroid_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/asteroid_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -302,7 +302,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/basket_loot_t2_ac" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/basket_loot_t2_ac" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/basket_loot_t2_ac" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -320,7 +320,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/big_hotspot_loot_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/big_hotspot_loot_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/big_hotspot_loot_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -338,7 +338,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/big_hotspot_loot_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/big_hotspot_loot_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/big_hotspot_loot_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -356,7 +356,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/big_hotspot_loot_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/big_hotspot_loot_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/big_hotspot_loot_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -374,7 +374,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/big_hotspot_loot_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/big_hotspot_loot_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/big_hotspot_loot_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -392,7 +392,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/bounty_hunter" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/bounty_hunter" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/bounty_hunter" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -410,7 +410,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/broken_tusker_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/broken_tusker_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/broken_tusker_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -428,7 +428,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/broken_tusker_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/broken_tusker_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/broken_tusker_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -446,7 +446,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/broken_tusker_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/broken_tusker_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/broken_tusker_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -464,7 +464,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/broken_tusker_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/broken_tusker_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/broken_tusker_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -482,7 +482,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/broken_tusker_5" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/broken_tusker_5" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/broken_tusker_5" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -500,7 +500,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/cowardly_rupu" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/cowardly_rupu" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/cowardly_rupu" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -518,7 +518,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/crane" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/crane" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/crane" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -536,7 +536,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/desert_clam" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/desert_clam" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/desert_clam" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -554,7 +554,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_camp_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_camp_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_camp_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -572,7 +572,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_camp_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_camp_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_camp_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -590,7 +590,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_camp_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_camp_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_camp_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -608,7 +608,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_camp_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_camp_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_camp_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -626,7 +626,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -644,7 +644,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_t1_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_t1_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_t1_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -662,7 +662,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -680,7 +680,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_t2_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_t2_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_t2_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -698,7 +698,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -716,7 +716,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_t3_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_t3_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_t3_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -734,7 +734,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -752,7 +752,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/easy_rupu_t4_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/easy_rupu_t4_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/easy_rupu_t4_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -770,7 +770,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/excavation_site_(2)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/excavation_site_(2)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/excavation_site_(2)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -788,7 +788,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/excavation_site_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/excavation_site_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/excavation_site_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -806,7 +806,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/falling_cactus" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/falling_cactus" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/falling_cactus" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -824,7 +824,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/falling_driftwood_tree" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/falling_driftwood_tree" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/falling_driftwood_tree" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -842,7 +842,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/falling_oasis_tree" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/falling_oasis_tree" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/falling_oasis_tree" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -860,7 +860,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/falling_rib_cage" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/falling_rib_cage" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/falling_rib_cage" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -878,7 +878,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/falling_stone" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/falling_stone" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/falling_stone" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -896,7 +896,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/falling_thornberry" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/falling_thornberry" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/falling_thornberry" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -914,7 +914,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/fire_elemental" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/fire_elemental" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/fire_elemental" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -932,7 +932,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/fire_fortress" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/fire_fortress" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/fire_fortress" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -950,7 +950,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/foragers_outpost_(1)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/foragers_outpost_(1)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/foragers_outpost_(1)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -968,7 +968,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/foragers_outpost_(2)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/foragers_outpost_(2)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/foragers_outpost_(2)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -986,7 +986,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/foragers_outpost_(3)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/foragers_outpost_(3)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/foragers_outpost_(3)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1004,7 +1004,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/foragers_outpost_(4)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/foragers_outpost_(4)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/foragers_outpost_(4)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1022,7 +1022,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/foragers_outpost_(5)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/foragers_outpost_(5)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/foragers_outpost_(5)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1040,7 +1040,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/foragers_outpost_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/foragers_outpost_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/foragers_outpost_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1058,7 +1058,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/fortified_rupu_town" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/fortified_rupu_town" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/fortified_rupu_town" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1076,7 +1076,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/fortified_rupu_village_(2)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/fortified_rupu_village_(2)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/fortified_rupu_village_(2)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1094,7 +1094,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/fortified_rupu_village_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/fortified_rupu_village_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/fortified_rupu_village_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1112,7 +1112,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/gas_thrower" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/gas_thrower" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/gas_thrower" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1130,7 +1130,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/go_go_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/go_go_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/go_go_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1148,7 +1148,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/go_go_t4_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/go_go_t4_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/go_go_t4_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1166,7 +1166,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/gogo" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/gogo" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/gogo" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1184,7 +1184,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/grave_digger" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/grave_digger" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/grave_digger" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1202,7 +1202,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/great_rupu_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/great_rupu_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/great_rupu_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1220,7 +1220,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/green_rupu" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/green_rupu" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/green_rupu" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1238,7 +1238,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_camp_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_camp_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_camp_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1256,7 +1256,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_camp_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_camp_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_camp_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1274,7 +1274,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_camp_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_camp_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_camp_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1292,7 +1292,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_camp_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_camp_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_camp_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1310,7 +1310,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1328,7 +1328,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_t1_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_t1_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_t1_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1346,7 +1346,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1364,7 +1364,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_t2_ac" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_t2_ac" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_t2_ac" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1382,7 +1382,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_t2_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_t2_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_t2_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1400,7 +1400,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1418,7 +1418,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_t3_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_t3_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_t3_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1436,7 +1436,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1454,7 +1454,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hard_rupu_t4_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hard_rupu_t4_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hard_rupu_t4_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1472,7 +1472,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hotspot_loot_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hotspot_loot_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hotspot_loot_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1490,7 +1490,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hotspot_loot_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hotspot_loot_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hotspot_loot_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1508,7 +1508,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hotspot_loot_t2_ac" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hotspot_loot_t2_ac" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hotspot_loot_t2_ac" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1526,7 +1526,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hotspot_loot_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hotspot_loot_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hotspot_loot_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1544,7 +1544,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hotspot_loot_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hotspot_loot_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hotspot_loot_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1562,7 +1562,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/hotspot_loot_windmill_t2_ac" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/hotspot_loot_windmill_t2_ac" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/hotspot_loot_windmill_t2_ac" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1580,7 +1580,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/koa" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/koa" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/koa" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1598,7 +1598,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/koa_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/koa_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/koa_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1616,7 +1616,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/koa_t4_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/koa_t4_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/koa_t4_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1634,7 +1634,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/large_nurr_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/large_nurr_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/large_nurr_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1652,7 +1652,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/large_nurr_t2_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/large_nurr_t2_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/large_nurr_t2_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1670,7 +1670,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/lava_papak" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/lava_papak" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/lava_papak" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1688,7 +1688,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/lazaward" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/lazaward" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/lazaward" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1706,7 +1706,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/leaning_fortress" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/leaning_fortress" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/leaning_fortress" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1724,7 +1724,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/loot_box_armors" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/loot_box_armors" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/loot_box_armors" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1742,7 +1742,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/loot_box_equipment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/loot_box_equipment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/loot_box_equipment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1760,7 +1760,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/loot_box_modules" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/loot_box_modules" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/loot_box_modules" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1778,7 +1778,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/loot_box_rigs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/loot_box_rigs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/loot_box_rigs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1796,7 +1796,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/loot_box_schematics_template_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/loot_box_schematics_template_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/loot_box_schematics_template_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1814,7 +1814,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/loot_box_tablets" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/loot_box_tablets" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/loot_box_tablets" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1832,7 +1832,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/loot_box_tools" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/loot_box_tools" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/loot_box_tools" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1850,7 +1850,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/loot_box_weapons" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/loot_box_weapons" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/loot_box_weapons" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1868,7 +1868,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/lootbox_armors_canyon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/lootbox_armors_canyon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/lootbox_armors_canyon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1886,7 +1886,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/lootbox_potions_template_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/lootbox_potions_template_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/lootbox_potions_template_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1904,7 +1904,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/lootbox_schematics_template_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/lootbox_schematics_template_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/lootbox_schematics_template_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1922,7 +1922,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/lootbox_schematics_template_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/lootbox_schematics_template_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/lootbox_schematics_template_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1940,7 +1940,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/lootbox_toolsand_equipment_canyon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/lootbox_toolsand_equipment_canyon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/lootbox_toolsand_equipment_canyon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1958,7 +1958,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/lootbox_weapons_canyon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/lootbox_weapons_canyon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/lootbox_weapons_canyon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1976,7 +1976,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/marshland_stalker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/marshland_stalker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/marshland_stalker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1994,7 +1994,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/matriarch" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/matriarch" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/matriarch" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2012,7 +2012,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_camp_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_camp_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_camp_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2030,7 +2030,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_camp_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_camp_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_camp_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2048,7 +2048,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_camp_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_camp_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_camp_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2066,7 +2066,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_camp_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_camp_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_camp_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2084,7 +2084,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2102,7 +2102,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_t1_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_t1_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_t1_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2120,7 +2120,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2138,7 +2138,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_t2_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_t2_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_t2_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2156,7 +2156,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2174,7 +2174,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_t3_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_t3_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_t3_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2192,7 +2192,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2210,7 +2210,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/medium_rupu_t4_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/medium_rupu_t4_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/medium_rupu_t4_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2228,7 +2228,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/mountable_nurr" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/mountable_nurr" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/mountable_nurr" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2246,7 +2246,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/mushroom_gas" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/mushroom_gas" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/mushroom_gas" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2264,7 +2264,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/nurr_(killin)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/nurr_(killin)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/nurr_(killin)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2282,7 +2282,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/nurr_(nurr)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/nurr_(nurr)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/nurr_(nurr)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2300,7 +2300,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/nurr_lair" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/nurr_lair" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/nurr_lair" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2318,7 +2318,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/nurr_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/nurr_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/nurr_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2336,7 +2336,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/nurr_raiding_camp" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/nurr_raiding_camp" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/nurr_raiding_camp" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2354,7 +2354,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/nurr_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/nurr_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/nurr_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2372,7 +2372,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/nurr_t2_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/nurr_t2_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/nurr_t2_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2390,7 +2390,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/okkam" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/okkam" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/okkam" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2408,7 +2408,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/okkam_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/okkam_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/okkam_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2426,7 +2426,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/okkam_t3_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/okkam_t3_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/okkam_t3_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2444,7 +2444,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/papak" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/papak" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/papak" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2462,7 +2462,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/papak_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/papak_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/papak_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2480,7 +2480,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/papak_t3_q" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/papak_t3_q" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/papak_t3_q" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2498,7 +2498,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/phemke_nest" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/phemke_nest" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/phemke_nest" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2516,7 +2516,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/phemke_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/phemke_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/phemke_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2534,7 +2534,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/prophet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/prophet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/prophet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2552,7 +2552,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/reinforced_rupu_outpost_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/reinforced_rupu_outpost_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/reinforced_rupu_outpost_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2570,7 +2570,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rock_thrower" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rock_thrower" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rock_thrower" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2588,7 +2588,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/ruined_fortress" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/ruined_fortress" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/ruined_fortress" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2606,7 +2606,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_artillery_camp" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_artillery_camp" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_artillery_camp" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2624,7 +2624,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_ashdweller" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_ashdweller" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_ashdweller" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2642,7 +2642,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_berserker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_berserker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_berserker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2660,7 +2660,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_campfire_site_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_campfire_site_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_campfire_site_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2678,7 +2678,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_cave" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_cave" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_cave" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2696,7 +2696,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_defensive_storage" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_defensive_storage" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_defensive_storage" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2714,7 +2714,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_drudge_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_drudge_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_drudge_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2732,7 +2732,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_dunestalker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_dunestalker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_dunestalker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2750,7 +2750,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_firebrand" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_firebrand" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_firebrand" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2768,7 +2768,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_forager" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_forager" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_forager" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2786,7 +2786,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_forerunner_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_forerunner_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_forerunner_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2804,7 +2804,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_fortress" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_fortress" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_fortress" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2822,7 +2822,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_gifting_altar_(4)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_gifting_altar_(4)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_gifting_altar_(4)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2840,7 +2840,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_gifting_altar_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_gifting_altar_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_gifting_altar_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2858,7 +2858,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_gunner" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_gunner" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_gunner" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2876,7 +2876,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_habitat" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_habitat" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_habitat" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2894,7 +2894,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_harasser_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_harasser_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_harasser_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2912,7 +2912,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_hazraki" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_hazraki" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_hazraki" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2930,7 +2930,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_hermit" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_hermit" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_hermit" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2948,7 +2948,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_hero_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_hero_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_hero_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2966,7 +2966,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_hunter" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_hunter" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_hunter" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2984,7 +2984,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_moisture_collector" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_moisture_collector" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_moisture_collector" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3002,7 +3002,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_observation_point" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_observation_point" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_observation_point" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3020,7 +3020,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_oracle_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_oracle_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_oracle_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3038,7 +3038,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_overseer_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_overseer_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_overseer_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3056,7 +3056,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_plainstrider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_plainstrider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_plainstrider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3074,7 +3074,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_prayer_site" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_prayer_site" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_prayer_site" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3092,7 +3092,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_priestess_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_priestess_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_priestess_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3110,7 +3110,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_rabble" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_rabble" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_rabble" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3128,7 +3128,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3146,7 +3146,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_raiding_checkpoint" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_raiding_checkpoint" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_raiding_checkpoint" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3164,7 +3164,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_scavenger" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_scavenger" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_scavenger" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3182,7 +3182,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_scuttler" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_scuttler" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_scuttler" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3200,7 +3200,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_seeker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_seeker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_seeker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3218,7 +3218,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_sentinel" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_sentinel" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_sentinel" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3236,7 +3236,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_shaman" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_shaman" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_shaman" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3254,7 +3254,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_shelter" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_shelter" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_shelter" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3272,7 +3272,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_skirmisher_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_skirmisher_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_skirmisher_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3290,7 +3290,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_thug" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_thug" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_thug" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3308,7 +3308,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_warrior" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_warrior" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_warrior" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3326,7 +3326,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_watch_tower_(1)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_watch_tower_(1)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_watch_tower_(1)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3344,7 +3344,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_watch_tower_(4)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_watch_tower_(4)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_watch_tower_(4)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3362,7 +3362,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_watch_tower_(6)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_watch_tower_(6)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_watch_tower_(6)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3380,7 +3380,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_watch_tower_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_watch_tower_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_watch_tower_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3398,7 +3398,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/rupu_zealot" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/rupu_zealot" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/rupu_zealot" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3416,7 +3416,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/sarcophagus_of_the_ancient" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/sarcophagus_of_the_ancient" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/sarcophagus_of_the_ancient" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3434,7 +3434,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/small_rupu_hut_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/small_rupu_hut_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/small_rupu_hut_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3452,7 +3452,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/small_rupu_outpost_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/small_rupu_outpost_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/small_rupu_outpost_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3470,7 +3470,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/small_rupu_village_(rupu)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/small_rupu_village_(rupu)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/small_rupu_village_(rupu)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3488,7 +3488,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/small_worm" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/small_worm" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/small_worm" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3506,7 +3506,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/sunken_temple" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/sunken_temple" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/sunken_temple" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3524,7 +3524,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/tar_dweller" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/tar_dweller" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/tar_dweller" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3542,7 +3542,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/temple_of_stars" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/temple_of_stars" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/temple_of_stars" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3560,7 +3560,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/the_long_one" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/the_long_one" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/the_long_one" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3578,7 +3578,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/tower_of_the_holly_fire" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/tower_of_the_holly_fire" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/tower_of_the_holly_fire" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3596,7 +3596,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/toxic_papak" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/toxic_papak" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/toxic_papak" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3614,7 +3614,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/toxic_war_papak" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/toxic_war_papak" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/toxic_war_papak" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3632,7 +3632,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/treasure_chest_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/treasure_chest_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/treasure_chest_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3650,7 +3650,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/treasure_chest_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/treasure_chest_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/treasure_chest_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3668,7 +3668,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/treasure_chest_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/treasure_chest_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/treasure_chest_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3686,7 +3686,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/treasure_chest_t4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/treasure_chest_t4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/treasure_chest_t4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3704,7 +3704,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/tutorial_beat_stick_loot" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/tutorial_beat_stick_loot" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/tutorial_beat_stick_loot" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3722,7 +3722,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/tutorial_completed_loot" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/tutorial_completed_loot" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/tutorial_completed_loot" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3740,7 +3740,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/war_okkam" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/war_okkam" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/war_okkam" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3758,7 +3758,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/water_condenser" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/water_condenser" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/water_condenser" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3776,7 +3776,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/water_condenser_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/water_condenser_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/water_condenser_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3794,7 +3794,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/water_condenser_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/water_condenser_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/water_condenser_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3812,7 +3812,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/white_death_(t2)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/white_death_(t2)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/white_death_(t2)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3830,7 +3830,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/white_death_(t3)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/white_death_(t3)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/white_death_(t3)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3848,7 +3848,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/yellow_rupu" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/yellow_rupu" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/yellow_rupu" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3866,7 +3866,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature/zharvakko" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature/zharvakko" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature/zharvakko" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/public/sitemap-items.xml
+++ b/public/sitemap-items.xml
@@ -14,7 +14,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/admin_wingsuit" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/admin_wingsuit" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/admin_wingsuit" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -32,7 +32,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_armors" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_armors" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_armors" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -50,7 +50,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_armors_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_armors_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_armors_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -68,7 +68,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_capital_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_capital_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_capital_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -86,7 +86,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_constructions" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_constructions" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_constructions" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -104,7 +104,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_constructions_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_constructions_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_constructions_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -122,7 +122,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_crafting_stations_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_crafting_stations_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_crafting_stations_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -140,7 +140,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_equipment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_equipment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_equipment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -158,7 +158,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_fiberworking_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_fiberworking_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_fiberworking_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -176,7 +176,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_furnace" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_furnace" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_furnace" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -194,7 +194,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_large_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_large_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_large_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -212,7 +212,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_medium_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_medium_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_medium_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -230,7 +230,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_potions" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_potions" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_potions" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -248,7 +248,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_stomping_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_stomping_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_stomping_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -266,7 +266,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_tools" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_tools" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_tools" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -284,7 +284,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_tools_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_tools_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_tools_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -302,7 +302,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_walker_parts" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_walker_parts" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_walker_parts" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -320,7 +320,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_walker_parts_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_walker_parts_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_walker_parts_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -338,7 +338,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_walker_weapons" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_walker_weapons" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_walker_weapons" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -356,7 +356,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_walker_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_walker_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_walker_weapons_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -374,7 +374,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_walkers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_walkers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_walkers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -392,7 +392,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_weapons" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_weapons" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_weapons" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -410,7 +410,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_weapons_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -428,7 +428,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_windmill" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_windmill" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_windmill" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -446,7 +446,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/advanced_woodworking_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/advanced_woodworking_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/advanced_woodworking_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -464,7 +464,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/aloe_gel" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/aloe_gel" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/aloe_gel" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -482,7 +482,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/aloe_goo_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/aloe_goo_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/aloe_goo_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -500,7 +500,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/aloe_vera" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/aloe_vera" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/aloe_vera" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -518,7 +518,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ammo" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ammo" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ammo" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -536,7 +536,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ammo_chest" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ammo_chest" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ammo_chest" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -554,7 +554,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ammo_scroll_rack" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ammo_scroll_rack" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ammo_scroll_rack" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -572,7 +572,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ancient_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ancient_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ancient_repair_hammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -590,7 +590,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/animal_fat" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/animal_fat" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/animal_fat" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -608,7 +608,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/animals_tablet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/animals_tablet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/animals_tablet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -626,7 +626,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/anti-personnel_turret" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/anti-personnel_turret" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/anti-personnel_turret" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -644,7 +644,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/apple" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/apple" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/apple" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -662,7 +662,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/apple_kambaro" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/apple_kambaro" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/apple_kambaro" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -680,7 +680,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/arena_fence_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/arena_fence_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/arena_fence_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -698,7 +698,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/arena_fence_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/arena_fence_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/arena_fence_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -716,7 +716,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/armor_shipment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/armor_shipment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/armor_shipment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -734,7 +734,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/armor_strongbox" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/armor_strongbox" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/armor_strongbox" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -752,7 +752,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/armored_capital_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/armored_capital_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/armored_capital_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -770,7 +770,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/armored_large_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/armored_large_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/armored_large_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -788,7 +788,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/armored_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/armored_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/armored_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -806,7 +806,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/armored_medium_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/armored_medium_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/armored_medium_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -824,7 +824,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/armored_small_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/armored_small_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/armored_small_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -842,7 +842,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/armors" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/armors" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/armors" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -860,7 +860,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/armoury_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/armoury_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/armoury_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -878,7 +878,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/artificer_woodworking_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/artificer_woodworking_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/artificer_woodworking_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -896,7 +896,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/artisan_fiberworking_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/artisan_fiberworking_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/artisan_fiberworking_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -914,7 +914,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/artisan_soil_auger" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/artisan_soil_auger" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/artisan_soil_auger" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -932,7 +932,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ash" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ash" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ash" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -950,7 +950,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/automaton" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/automaton" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/automaton" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -968,7 +968,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/automaton_controller" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/automaton_controller" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/automaton_controller" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -986,7 +986,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balaclava" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balaclava" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balaclava" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1004,7 +1004,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1022,7 +1022,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1040,7 +1040,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1058,7 +1058,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1076,7 +1076,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1094,7 +1094,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1112,7 +1112,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1130,7 +1130,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1148,7 +1148,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1166,7 +1166,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1184,7 +1184,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1202,7 +1202,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1220,7 +1220,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1238,7 +1238,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1256,7 +1256,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1274,7 +1274,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1292,7 +1292,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/balang_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/balang_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/balang_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1310,7 +1310,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ballista" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ballista" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ballista" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1328,7 +1328,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ballista_-_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ballista_-_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ballista_-_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1346,7 +1346,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ballista_-_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ballista_-_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ballista_-_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1364,7 +1364,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ballista_-_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ballista_-_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ballista_-_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1382,7 +1382,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/banner_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/banner_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/banner_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1400,7 +1400,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/banner_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/banner_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/banner_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1418,7 +1418,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/banner_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/banner_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/banner_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1436,7 +1436,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/barrier_base" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/barrier_base" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/barrier_base" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1454,7 +1454,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/barrier_gate" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/barrier_gate" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/barrier_gate" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1472,7 +1472,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/barrier_plank" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/barrier_plank" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/barrier_plank" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1490,7 +1490,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/base_container" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/base_container" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/base_container" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1508,7 +1508,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/base_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/base_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/base_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1526,7 +1526,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/base_maintenance_chest" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/base_maintenance_chest" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/base_maintenance_chest" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1544,7 +1544,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/base_packing_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/base_packing_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/base_packing_-_tier_1_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1562,7 +1562,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/base_packing_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/base_packing_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/base_packing_-_tier_2_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1580,7 +1580,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/base_packing_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/base_packing_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/base_packing_-_tier_3_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1598,7 +1598,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/base_packing_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/base_packing_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/base_packing_-_tier_4_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1616,7 +1616,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/base_walker_parts" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/base_walker_parts" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/base_walker_parts" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1634,7 +1634,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/base_walker_parts_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/base_walker_parts_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/base_walker_parts_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1652,7 +1652,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/base_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/base_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/base_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1670,7 +1670,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_armors" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_armors" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_armors" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1688,7 +1688,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_armors_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_armors_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_armors_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1706,7 +1706,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_constructions" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_constructions" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_constructions" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1724,7 +1724,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_constructions_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_constructions_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_constructions_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1742,7 +1742,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_crafting_stations_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_crafting_stations_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_crafting_stations_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1760,7 +1760,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_equipment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_equipment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_equipment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1778,7 +1778,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_potions" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_potions" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_potions" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1796,7 +1796,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_protection" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_protection" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_protection" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1814,7 +1814,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_tools" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_tools" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_tools" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1832,7 +1832,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_tools_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_tools_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_tools_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1850,7 +1850,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_walker_weapons" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_walker_weapons" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_walker_weapons" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1868,7 +1868,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_walker_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_walker_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_walker_weapons_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1886,7 +1886,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_walkers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_walkers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_walkers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1904,7 +1904,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_weapons" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_weapons" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_weapons" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1922,7 +1922,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basic_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basic_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basic_weapons_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1940,7 +1940,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basket_open" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basket_open" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basket_open" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1958,7 +1958,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basket_tall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basket_tall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basket_tall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1976,7 +1976,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/basket_wide" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/basket_wide" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/basket_wide" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -1994,7 +1994,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/baskwood_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/baskwood_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/baskwood_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2012,7 +2012,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/baskwood_boots" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/baskwood_boots" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/baskwood_boots" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2030,7 +2030,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/baskwood_bracers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/baskwood_bracers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/baskwood_bracers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2048,7 +2048,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battery_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battery_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battery_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2066,7 +2066,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battle_fan" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battle_fan" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battle_fan" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2084,7 +2084,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battlements" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battlements" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battlements" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2102,7 +2102,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battleship_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battleship_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battleship_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2120,7 +2120,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battleship_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battleship_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battleship_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2138,7 +2138,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battleship_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battleship_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battleship_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2156,7 +2156,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battleship_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battleship_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battleship_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2174,7 +2174,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battleship_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battleship_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battleship_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2192,7 +2192,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battleship_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battleship_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battleship_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2210,7 +2210,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battleship_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battleship_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battleship_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2228,7 +2228,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battleship_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battleship_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battleship_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2246,7 +2246,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/battleship_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/battleship_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/battleship_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2264,7 +2264,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/beat_stick" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/beat_stick" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/beat_stick" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2282,7 +2282,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bed" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bed" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bed" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2300,7 +2300,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/beeswax" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/beeswax" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/beeswax" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2318,7 +2318,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bent_wooden_planks" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bent_wooden_planks" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bent_wooden_planks" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2336,7 +2336,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/big_roped_ladder" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/big_roped_ladder" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/big_roped_ladder" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2354,7 +2354,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/blacksmith_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/blacksmith_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/blacksmith_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2372,7 +2372,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/blood_turnip" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/blood_turnip" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/blood_turnip" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2390,7 +2390,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/blunt_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/blunt_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/blunt_quarterstaff" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2408,7 +2408,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/boarding_plank" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/boarding_plank" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/boarding_plank" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2426,7 +2426,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bomb_chest_trap" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bomb_chest_trap" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bomb_chest_trap" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2444,7 +2444,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bomb_javelin" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bomb_javelin" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bomb_javelin" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2462,7 +2462,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bombolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bombolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bombolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2480,7 +2480,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_bolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_bolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_bolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2498,7 +2498,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_bottle" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_bottle" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_bottle" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2516,7 +2516,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_dart" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_dart" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_dart" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2534,7 +2534,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_effigy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_effigy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_effigy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2552,7 +2552,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_glue" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_glue" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_glue" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2570,7 +2570,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_harpoon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_harpoon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_harpoon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2588,7 +2588,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_pickaxe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_pickaxe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_pickaxe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2606,7 +2606,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_repair_hammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2624,7 +2624,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_scattershot_ammo" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_scattershot_ammo" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_scattershot_ammo" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2642,7 +2642,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_sickle" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_sickle" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_sickle" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2660,7 +2660,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bone_splinter" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bone_splinter" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bone_splinter" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2678,7 +2678,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bonebreaker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bonebreaker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bonebreaker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2696,7 +2696,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bones_pile" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bones_pile" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bones_pile" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2714,7 +2714,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bonespike_sword" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bonespike_sword" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bonespike_sword" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2732,7 +2732,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/brazier" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/brazier" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/brazier" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2750,7 +2750,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/brine" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/brine" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/brine" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2768,7 +2768,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/brittle_bone_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/brittle_bone_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/brittle_bone_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2786,7 +2786,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/brittle_bone_boots" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/brittle_bone_boots" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/brittle_bone_boots" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2804,7 +2804,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/brittle_bone_handwraps" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/brittle_bone_handwraps" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/brittle_bone_handwraps" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2822,7 +2822,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/broken_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/broken_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/broken_grappling_hook" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2840,7 +2840,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bucket_helmet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bucket_helmet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bucket_helmet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2858,7 +2858,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2876,7 +2876,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2894,7 +2894,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2912,7 +2912,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2930,7 +2930,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2948,7 +2948,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2966,7 +2966,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -2984,7 +2984,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3002,7 +3002,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3020,7 +3020,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3038,7 +3038,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3056,7 +3056,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3074,7 +3074,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3092,7 +3092,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3110,7 +3110,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3128,7 +3128,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3146,7 +3146,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3164,7 +3164,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3182,7 +3182,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3200,7 +3200,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3218,7 +3218,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3236,7 +3236,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3254,7 +3254,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3272,7 +3272,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3290,7 +3290,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3308,7 +3308,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3326,7 +3326,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3344,7 +3344,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3362,7 +3362,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3380,7 +3380,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3398,7 +3398,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3416,7 +3416,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3434,7 +3434,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3452,7 +3452,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3470,7 +3470,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3488,7 +3488,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3506,7 +3506,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3524,7 +3524,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3542,7 +3542,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3560,7 +3560,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3578,7 +3578,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3596,7 +3596,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3614,7 +3614,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3632,7 +3632,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3650,7 +3650,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3668,7 +3668,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/buffalo_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/buffalo_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/buffalo_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3686,7 +3686,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bullrush_base_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bullrush_base_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bullrush_base_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3704,7 +3704,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/bullrush_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/bullrush_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/bullrush_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3722,7 +3722,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cactus_flesh" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cactus_flesh" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cactus_flesh" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3740,7 +3740,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cage" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cage" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cage" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3758,7 +3758,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cage_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cage_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cage_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3776,7 +3776,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cage_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cage_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cage_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3794,7 +3794,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop__walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop__walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop__walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3812,7 +3812,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3830,7 +3830,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3848,7 +3848,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3866,7 +3866,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3884,7 +3884,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3902,7 +3902,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3920,7 +3920,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3938,7 +3938,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3956,7 +3956,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3974,7 +3974,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -3992,7 +3992,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camelop_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camelop_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camelop_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4010,7 +4010,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/camp_fire" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/camp_fire" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/camp_fire" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4028,7 +4028,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/capital_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/capital_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/capital_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4046,7 +4046,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/capital_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/capital_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/capital_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4064,7 +4064,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/carapace_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/carapace_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/carapace_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4082,7 +4082,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/carapace_boots" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/carapace_boots" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/carapace_boots" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4100,7 +4100,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/carapace_gauntlets" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/carapace_gauntlets" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/carapace_gauntlets" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4118,7 +4118,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cargo_hold_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cargo_hold_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cargo_hold_-_tier_1_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4136,7 +4136,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cargo_hold_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cargo_hold_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cargo_hold_-_tier_2_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4154,7 +4154,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cargo_hold_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cargo_hold_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cargo_hold_-_tier_3_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4172,7 +4172,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cargo_hold_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cargo_hold_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cargo_hold_-_tier_4_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4190,7 +4190,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/carpet_dark" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/carpet_dark" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/carpet_dark" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4208,7 +4208,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/carpet_light" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/carpet_light" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/carpet_light" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4226,7 +4226,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/catapult" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/catapult" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/catapult" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4244,7 +4244,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/catapult_boulder" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/catapult_boulder" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/catapult_boulder" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4262,7 +4262,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cattail" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cattail" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cattail" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4280,7 +4280,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cauterizing_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cauterizing_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cauterizing_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4298,7 +4298,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/celestial_tablet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/celestial_tablet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/celestial_tablet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4316,7 +4316,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_balang_core" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_balang_core" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_balang_core" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4334,7 +4334,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_battlements" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_battlements" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_battlements" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4352,7 +4352,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_corner" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_corner" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_corner" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4370,7 +4370,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_door" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_door" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_door" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4388,7 +4388,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_floor_/_roof" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4406,7 +4406,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_foundation" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_foundation" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_foundation" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4424,7 +4424,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_silur_core" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_silur_core" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_silur_core" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4442,7 +4442,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_wall_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_wall_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_wall_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4460,7 +4460,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_wall_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_wall_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_wall_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4478,7 +4478,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_wall_with_window_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_wall_with_window_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_wall_with_window_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4496,7 +4496,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_wall_with_window_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_wall_with_window_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_wall_with_window_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4514,7 +4514,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_wall_with_windows_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_wall_with_windows_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_wall_with_windows_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4532,7 +4532,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cement_wall_with_windows_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cement_wall_with_windows_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cement_wall_with_windows_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4550,7 +4550,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic_dart" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic_dart" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic_dart" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4568,7 +4568,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic_flask" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic_flask" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic_flask" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4586,7 +4586,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic_hatchet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic_hatchet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic_hatchet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4604,7 +4604,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic_nails" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic_nails" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic_nails" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4622,7 +4622,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic_orb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic_orb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic_orb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4640,7 +4640,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic_pickaxe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic_pickaxe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic_pickaxe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4658,7 +4658,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic_repair_hammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4676,7 +4676,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic_rok" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic_rok" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic_rok" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4694,7 +4694,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic_scattershot_ammo" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic_scattershot_ammo" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic_scattershot_ammo" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4712,7 +4712,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic_shard" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic_shard" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic_shard" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4730,7 +4730,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic-tipped_bolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic-tipped_bolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic-tipped_bolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4748,7 +4748,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ceramic-tipped_harpoon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ceramic-tipped_harpoon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ceramic-tipped_harpoon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4766,7 +4766,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chair_comfortable" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chair_comfortable" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chair_comfortable" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4784,7 +4784,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chair_simple" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chair_simple" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chair_simple" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4802,7 +4802,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chair_throne" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chair_throne" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chair_throne" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4820,7 +4820,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chalk_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chalk_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chalk_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4838,7 +4838,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/charcoal" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/charcoal" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/charcoal" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4856,7 +4856,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/charged_boulder" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/charged_boulder" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/charged_boulder" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4874,7 +4874,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/charged_rok" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/charged_rok" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/charged_rok" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4892,7 +4892,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chitin_dart" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chitin_dart" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chitin_dart" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4910,7 +4910,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chitin_harpoon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chitin_harpoon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chitin_harpoon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4928,7 +4928,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chitin_pickaxe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chitin_pickaxe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chitin_pickaxe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4946,7 +4946,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chitin_plate" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chitin_plate" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chitin_plate" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4964,7 +4964,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chitin_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chitin_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chitin_repair_hammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -4982,7 +4982,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chitin_shard_bolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chitin_shard_bolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chitin_shard_bolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5000,7 +5000,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/chitin_sickle" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/chitin_sickle" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/chitin_sickle" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5018,7 +5018,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cinema" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cinema" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cinema" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5036,7 +5036,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clan_flag" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clan_flag" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clan_flag" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5054,7 +5054,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clan_flag_hanging" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clan_flag_hanging" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clan_flag_hanging" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5072,7 +5072,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5090,7 +5090,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_battlement" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_battlement" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_battlement" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5108,7 +5108,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_corner" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_corner" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_corner" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5126,7 +5126,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_door" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_door" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_door" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5144,7 +5144,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_floor_/_roof" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5162,7 +5162,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_foundation" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_foundation" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_foundation" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5180,7 +5180,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_pot" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_pot" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_pot" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5198,7 +5198,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5216,7 +5216,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_wall_with_window" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_wall_with_window" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_wall_with_window" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5234,7 +5234,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_wall_with_windows" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_wall_with_windows" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_wall_with_windows" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5252,7 +5252,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_walls" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_walls" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_walls" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5270,7 +5270,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/clay_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/clay_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/clay_walls_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5288,7 +5288,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cloak" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cloak" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cloak" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5306,7 +5306,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cloaked_rupu_fur_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cloaked_rupu_fur_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cloaked_rupu_fur_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5324,7 +5324,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cluster_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cluster_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cluster_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5342,7 +5342,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5360,7 +5360,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5378,7 +5378,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5396,7 +5396,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5414,7 +5414,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5432,7 +5432,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5450,7 +5450,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5468,7 +5468,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5486,7 +5486,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5504,7 +5504,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5522,7 +5522,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5540,7 +5540,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5558,7 +5558,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5576,7 +5576,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5594,7 +5594,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5612,7 +5612,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cobra_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cobra_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cobra_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5630,7 +5630,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cog" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cog" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cog" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5648,7 +5648,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/common" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/common" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/common" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5666,7 +5666,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/compacted_torque_battery" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/compacted_torque_battery" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/compacted_torque_battery" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5684,7 +5684,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/concrete" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/concrete" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/concrete" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5702,7 +5702,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/concrete_walls" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/concrete_walls" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/concrete_walls" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5720,7 +5720,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/concrete_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/concrete_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/concrete_walls_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5738,7 +5738,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/construction" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/construction" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/construction" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5756,7 +5756,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/consumables" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/consumables" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/consumables" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5774,7 +5774,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/containers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/containers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/containers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5792,7 +5792,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/contaminated_water" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/contaminated_water" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/contaminated_water" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5810,7 +5810,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/contrabass" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/contrabass" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/contrabass" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5828,7 +5828,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cooked_corn" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cooked_corn" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cooked_corn" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5846,7 +5846,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/corn" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/corn" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/corn" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5864,7 +5864,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/corner" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/corner" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/corner" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5882,7 +5882,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/cotton" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/cotton" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/cotton" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5900,7 +5900,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/crafting" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/crafting" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/crafting" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5918,7 +5918,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/crafting_bench" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/crafting_bench" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/crafting_bench" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5936,7 +5936,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/craftsman_base_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/craftsman_base_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/craftsman_base_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5954,7 +5954,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/craftsman_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/craftsman_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/craftsman_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5972,7 +5972,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/crane" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/crane" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/crane" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -5990,7 +5990,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/crane_harpoon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/crane_harpoon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/crane_harpoon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6008,7 +6008,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/crate_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/crate_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/crate_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6026,7 +6026,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/crate_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/crate_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/crate_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6044,7 +6044,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/crude_hatchet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/crude_hatchet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/crude_hatchet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6062,7 +6062,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/crude_orb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/crude_orb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/crude_orb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6080,7 +6080,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/curing_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/curing_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/curing_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6098,7 +6098,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dance_mask" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dance_mask" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dance_mask" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6116,7 +6116,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/decal" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/decal" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/decal" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6134,7 +6134,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/decals" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/decals" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/decals" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6152,7 +6152,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/defenses" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/defenses" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/defenses" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6170,7 +6170,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/defensive_tower" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/defensive_tower" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/defensive_tower" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6188,7 +6188,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/delivery_package" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/delivery_package" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/delivery_package" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6206,7 +6206,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/delivery_token" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/delivery_token" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/delivery_token" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6224,7 +6224,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/desert_mule" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/desert_mule" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/desert_mule" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6242,7 +6242,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/didgeridoo" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/didgeridoo" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/didgeridoo" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6260,7 +6260,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_gate" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_gate" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_gate" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6278,7 +6278,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6296,7 +6296,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6314,7 +6314,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6332,7 +6332,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6350,7 +6350,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6368,7 +6368,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6386,7 +6386,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6404,7 +6404,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6422,7 +6422,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6440,7 +6440,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6458,7 +6458,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6476,7 +6476,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6494,7 +6494,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6512,7 +6512,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6530,7 +6530,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6548,7 +6548,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6566,7 +6566,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6584,7 +6584,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6602,7 +6602,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6620,7 +6620,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6638,7 +6638,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6656,7 +6656,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6674,7 +6674,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6692,7 +6692,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6710,7 +6710,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6728,7 +6728,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6746,7 +6746,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6764,7 +6764,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6782,7 +6782,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6800,7 +6800,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6818,7 +6818,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6836,7 +6836,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6854,7 +6854,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6872,7 +6872,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6890,7 +6890,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6908,7 +6908,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6926,7 +6926,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6944,7 +6944,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dinghy_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dinghy_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dinghy_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6962,7 +6962,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dirty_water" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dirty_water" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dirty_water" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6980,7 +6980,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/djembe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/djembe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/djembe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -6998,7 +6998,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7016,7 +7016,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7034,7 +7034,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7052,7 +7052,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7070,7 +7070,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7088,7 +7088,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7106,7 +7106,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7124,7 +7124,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7142,7 +7142,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7160,7 +7160,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7178,7 +7178,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7196,7 +7196,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7214,7 +7214,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7232,7 +7232,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7250,7 +7250,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7268,7 +7268,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7286,7 +7286,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7304,7 +7304,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7322,7 +7322,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7340,7 +7340,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7358,7 +7358,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7376,7 +7376,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7394,7 +7394,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7412,7 +7412,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7430,7 +7430,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7448,7 +7448,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7466,7 +7466,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7484,7 +7484,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7502,7 +7502,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7520,7 +7520,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7538,7 +7538,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7556,7 +7556,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7574,7 +7574,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7592,7 +7592,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7610,7 +7610,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7628,7 +7628,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7646,7 +7646,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7664,7 +7664,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7682,7 +7682,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7700,7 +7700,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7718,7 +7718,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7736,7 +7736,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7754,7 +7754,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7772,7 +7772,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7790,7 +7790,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7808,7 +7808,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/domus_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/domus_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/domus_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7826,7 +7826,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/door" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/door" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/door" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7844,7 +7844,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/double_slit_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/double_slit_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/double_slit_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7862,7 +7862,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/drill_spade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/drill_spade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/drill_spade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7880,7 +7880,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/durability_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/durability_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/durability_-_tier_1_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7898,7 +7898,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/durability_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/durability_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/durability_-_tier_2_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7916,7 +7916,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/durability_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/durability_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/durability_-_tier_3_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7934,7 +7934,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/durability_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/durability_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/durability_-_tier_4_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7952,7 +7952,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/durable_water_sack" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/durable_water_sack" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/durable_water_sack" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7970,7 +7970,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/dyeing_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/dyeing_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/dyeing_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -7988,7 +7988,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/earth_wax" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/earth_wax" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/earth_wax" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8006,7 +8006,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/elements_tablet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/elements_tablet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/elements_tablet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8024,7 +8024,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/epic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/epic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/epic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8042,7 +8042,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/equipment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/equipment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/equipment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8060,7 +8060,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/equipment_strongbox" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/equipment_strongbox" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/equipment_strongbox" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8078,7 +8078,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/eucalyptus_leaf" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/eucalyptus_leaf" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/eucalyptus_leaf" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8096,7 +8096,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/exoskeleton" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/exoskeleton" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/exoskeleton" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8114,7 +8114,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/explosive_bolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/explosive_bolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/explosive_bolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8132,7 +8132,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/explosive_boulder" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/explosive_boulder" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/explosive_boulder" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8150,7 +8150,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/explosive_dart" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/explosive_dart" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/explosive_dart" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8168,7 +8168,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8186,7 +8186,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8204,7 +8204,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8222,7 +8222,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8240,7 +8240,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8258,7 +8258,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8276,7 +8276,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8294,7 +8294,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8312,7 +8312,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8330,7 +8330,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8348,7 +8348,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8366,7 +8366,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8384,7 +8384,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8402,7 +8402,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8420,7 +8420,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8438,7 +8438,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8456,7 +8456,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8474,7 +8474,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8492,7 +8492,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8510,7 +8510,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8528,7 +8528,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8546,7 +8546,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8564,7 +8564,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8582,7 +8582,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8600,7 +8600,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8618,7 +8618,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8636,7 +8636,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8654,7 +8654,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8672,7 +8672,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8690,7 +8690,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8708,7 +8708,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8726,7 +8726,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8744,7 +8744,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8762,7 +8762,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8780,7 +8780,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8798,7 +8798,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8816,7 +8816,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8834,7 +8834,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8852,7 +8852,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8870,7 +8870,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8888,7 +8888,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8906,7 +8906,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8924,7 +8924,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8942,7 +8942,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8960,7 +8960,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8978,7 +8978,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falco_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falco_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falco_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -8996,7 +8996,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/falling_rock_trap" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/falling_rock_trap" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/falling_rock_trap" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9014,7 +9014,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/farmable_area" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/farmable_area" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/farmable_area" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9032,7 +9032,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fast_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fast_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fast_grappling_hook" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9050,7 +9050,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/feather" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/feather" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/feather" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9068,7 +9068,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/feather_boots" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/feather_boots" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/feather_boots" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9086,7 +9086,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/feather_mask" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/feather_mask" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/feather_mask" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9104,7 +9104,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fence_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fence_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fence_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9122,7 +9122,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fence_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fence_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fence_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9140,7 +9140,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fence_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fence_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fence_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9158,7 +9158,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fence_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fence_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fence_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9176,7 +9176,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fence_5" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fence_5" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fence_5" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9194,7 +9194,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fence_6" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fence_6" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fence_6" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9212,7 +9212,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/festive_turban" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/festive_turban" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/festive_turban" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9230,7 +9230,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fiber" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fiber" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fiber" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9248,7 +9248,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fiber_arm_wraps" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fiber_arm_wraps" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fiber_arm_wraps" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9266,7 +9266,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fiber_headwrap" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fiber_headwrap" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fiber_headwrap" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9284,7 +9284,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fiber_sandals" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fiber_sandals" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fiber_sandals" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9302,7 +9302,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fiber_shirt_and_trousers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fiber_shirt_and_trousers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fiber_shirt_and_trousers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9320,7 +9320,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fiber_weave" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fiber_weave" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fiber_weave" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9338,7 +9338,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fiberworking_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fiberworking_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fiberworking_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9356,7 +9356,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fire_bolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fire_bolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fire_bolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9374,7 +9374,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fire_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fire_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fire_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9392,7 +9392,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fire_dart" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fire_dart" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fire_dart" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9410,7 +9410,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fire_goblet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fire_goblet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fire_goblet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9428,7 +9428,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firebomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firebomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firebomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9446,7 +9446,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9464,7 +9464,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9482,7 +9482,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9500,7 +9500,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9518,7 +9518,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9536,7 +9536,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9554,7 +9554,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9572,7 +9572,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9590,7 +9590,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9608,7 +9608,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9626,7 +9626,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9644,7 +9644,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9662,7 +9662,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9680,7 +9680,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9698,7 +9698,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9716,7 +9716,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9734,7 +9734,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9752,7 +9752,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9770,7 +9770,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9788,7 +9788,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9806,7 +9806,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9824,7 +9824,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9842,7 +9842,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9860,7 +9860,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9878,7 +9878,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9896,7 +9896,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9914,7 +9914,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9932,7 +9932,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9950,7 +9950,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9968,7 +9968,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -9986,7 +9986,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10004,7 +10004,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10022,7 +10022,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firefly_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firefly_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firefly_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10040,7 +10040,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fireproof_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fireproof_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fireproof_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10058,7 +10058,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firestone_axe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firestone_axe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firestone_axe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10076,7 +10076,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firestone_battleaxe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firestone_battleaxe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firestone_battleaxe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10094,7 +10094,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firestone_bladestaff" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firestone_bladestaff" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firestone_bladestaff" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10112,7 +10112,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firestone_bludgeon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firestone_bludgeon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firestone_bludgeon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10130,7 +10130,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firestone_bozdogan" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firestone_bozdogan" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firestone_bozdogan" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10148,7 +10148,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firestone_hammerstaff" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firestone_hammerstaff" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firestone_hammerstaff" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10166,7 +10166,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firestone_kopesh" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firestone_kopesh" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firestone_kopesh" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10184,7 +10184,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firestone_longblade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firestone_longblade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firestone_longblade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10202,7 +10202,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firework_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firework_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firework_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10220,7 +10220,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firework_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firework_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firework_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10238,7 +10238,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firework_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firework_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firework_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10256,7 +10256,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firework_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firework_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firework_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10274,7 +10274,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firework_5" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firework_5" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firework_5" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10292,7 +10292,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firework_6" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firework_6" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firework_6" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10310,7 +10310,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/firework_7" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/firework_7" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/firework_7" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10328,7 +10328,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flag_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flag_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flag_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10346,7 +10346,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flag_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flag_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flag_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10364,7 +10364,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flag_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flag_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flag_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10382,7 +10382,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flag_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flag_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flag_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10400,7 +10400,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flag_5" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flag_5" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flag_5" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10418,7 +10418,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flag_6" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flag_6" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flag_6" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10436,7 +10436,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flag_7" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flag_7" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flag_7" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10454,7 +10454,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flare_-_blue" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flare_-_blue" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flare_-_blue" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10472,7 +10472,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flare_-_green" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flare_-_green" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flare_-_green" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10490,7 +10490,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flare_-_orange" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flare_-_orange" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flare_-_orange" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10508,7 +10508,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flare_-_purple" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flare_-_purple" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flare_-_purple" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10526,7 +10526,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flare_-_red" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flare_-_red" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flare_-_red" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10544,7 +10544,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flare_-_teal" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flare_-_teal" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flare_-_teal" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10562,7 +10562,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flare_-_white" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flare_-_white" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flare_-_white" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10580,7 +10580,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flares" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flares" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flares" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10598,7 +10598,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flint" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flint" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flint" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10616,7 +10616,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flint_bolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flint_bolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flint_bolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10634,7 +10634,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flint_harpoon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flint_harpoon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flint_harpoon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10652,7 +10652,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flint_orb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flint_orb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flint_orb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10670,7 +10670,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/floating_mine" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/floating_mine" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/floating_mine" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10688,7 +10688,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/floor_/_roof" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10706,7 +10706,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillan_capital_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillan_capital_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillan_capital_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10724,7 +10724,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillan_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillan_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillan_grappling_hook" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10742,7 +10742,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillan_large_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillan_large_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillan_large_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10760,7 +10760,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillan_medium_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillan_medium_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillan_medium_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10778,7 +10778,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillan_walker_parts" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillan_walker_parts" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillan_walker_parts" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10796,7 +10796,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillan_walker_parts_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillan_walker_parts_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillan_walker_parts_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10814,7 +10814,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_armors" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_armors" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_armors" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10832,7 +10832,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_armors_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_armors_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_armors_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10850,7 +10850,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_constructions" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_constructions" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_constructions" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10868,7 +10868,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_constructions_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_constructions_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_constructions_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10886,7 +10886,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_crafting_stations_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_crafting_stations_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_crafting_stations_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10904,7 +10904,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_equipment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_equipment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_equipment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10922,7 +10922,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_potions" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_potions" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_potions" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10940,7 +10940,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_stomping_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_stomping_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_stomping_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10958,7 +10958,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_tools" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_tools" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_tools" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10976,7 +10976,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_tools_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_tools_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_tools_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -10994,7 +10994,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_walker_parts" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_walker_parts" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_walker_parts" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11012,7 +11012,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_walker_weapons" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_walker_weapons" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_walker_weapons" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11030,7 +11030,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_walker_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_walker_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_walker_weapons_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11048,7 +11048,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_walkers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_walkers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_walkers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11066,7 +11066,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_weapons" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_weapons" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_weapons" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11084,7 +11084,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flotillian_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flotillian_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flotillian_weapons_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11102,7 +11102,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/flots" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/flots" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/flots" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11120,7 +11120,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/forager_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/forager_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/forager_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11138,7 +11138,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/foraging_pouch" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/foraging_pouch" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/foraging_pouch" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11156,7 +11156,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/force_field" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/force_field" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/force_field" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11174,7 +11174,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/forebear_coin" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/forebear_coin" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/forebear_coin" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11192,7 +11192,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/forester&apos;s_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/forester&apos;s_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/forester&apos;s_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11210,7 +11210,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/forester&apos;s_sandals" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/forester&apos;s_sandals" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/forester&apos;s_sandals" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11228,7 +11228,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/forester&apos;s_sleeves" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/forester&apos;s_sleeves" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/forester&apos;s_sleeves" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11246,7 +11246,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fortress_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fortress_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fortress_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11264,7 +11264,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/foundation" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/foundation" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/foundation" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11282,7 +11282,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fragment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fragment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fragment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11300,7 +11300,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fragment_strongbox" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fragment_strongbox" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fragment_strongbox" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11318,7 +11318,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/friend_nomad" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/friend_nomad" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/friend_nomad" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11336,7 +11336,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fruit_pulp" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fruit_pulp" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fruit_pulp" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11354,7 +11354,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/furnace" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/furnace" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/furnace" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11372,7 +11372,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/furniture" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/furniture" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/furniture" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11390,7 +11390,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/fury_fumes" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/fury_fumes" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/fury_fumes" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11408,7 +11408,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gas_mask" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gas_mask" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gas_mask" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11426,7 +11426,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gate_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gate_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gate_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11444,7 +11444,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gear_storage_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gear_storage_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gear_storage_-_tier_1_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11462,7 +11462,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gear_storage_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gear_storage_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gear_storage_-_tier_2_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11480,7 +11480,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gear_storage_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gear_storage_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gear_storage_-_tier_3_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11498,7 +11498,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gear_storage_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gear_storage_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gear_storage_-_tier_4_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11516,7 +11516,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gelatinous_goo" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gelatinous_goo" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gelatinous_goo" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11534,7 +11534,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/giant_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/giant_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/giant_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11552,7 +11552,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/giant_wall_gate" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/giant_wall_gate" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/giant_wall_gate" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11570,7 +11570,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/giant_wall_packer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/giant_wall_packer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/giant_wall_packer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11588,7 +11588,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gigantic_chest" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gigantic_chest" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gigantic_chest" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11606,7 +11606,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/glass" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/glass" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/glass" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11624,7 +11624,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/grappling_belt_charging_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/grappling_belt_charging_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/grappling_belt_charging_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11642,7 +11642,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/green_death_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/green_death_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/green_death_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11660,7 +11660,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gun_pod" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gun_pod" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gun_pod" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11678,7 +11678,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gun_pod_plating" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gun_pod_plating" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gun_pod_plating" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11696,7 +11696,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gun_pod_shell" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gun_pod_shell" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gun_pod_shell" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11714,7 +11714,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gun_pods" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gun_pods" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gun_pods" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11732,7 +11732,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gunpod_ballista" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gunpod_ballista" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gunpod_ballista" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11750,7 +11750,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/gunpod_stinger" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/gunpod_stinger" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/gunpod_stinger" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11768,7 +11768,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hammock" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hammock" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hammock" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11786,7 +11786,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hangar_gate" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hangar_gate" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hangar_gate" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11804,7 +11804,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hangar_roof" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hangar_roof" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hangar_roof" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11822,7 +11822,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hangar_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hangar_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hangar_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11840,7 +11840,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hangar_wall_with_door" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hangar_wall_with_door" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hangar_wall_with_door" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11858,7 +11858,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hardened_hellfire_bolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hardened_hellfire_bolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hardened_hellfire_bolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11876,7 +11876,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hardening_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hardening_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hardening_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11894,7 +11894,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/harpoon_protection_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/harpoon_protection_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/harpoon_protection_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11912,7 +11912,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/haysludge_arch" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/haysludge_arch" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/haysludge_arch" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11930,7 +11930,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/haysludge_fence" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/haysludge_fence" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/haysludge_fence" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11948,7 +11948,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hearth_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hearth_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hearth_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11966,7 +11966,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_backpack" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_backpack" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_backpack" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -11984,7 +11984,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_capital_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_capital_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_capital_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12002,7 +12002,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_javelin" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_javelin" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_javelin" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12020,7 +12020,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_large_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_large_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_large_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12038,7 +12038,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12056,7 +12056,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_medium_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_medium_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_medium_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12074,7 +12074,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_rawbone_hand_axe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_rawbone_hand_axe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_rawbone_hand_axe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12092,7 +12092,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_walls" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_walls" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_walls" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12110,7 +12110,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_walls_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12128,7 +12128,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12146,7 +12146,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_wood_battlements" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_wood_battlements" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_wood_battlements" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12164,7 +12164,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_wood_corner" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_wood_corner" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_wood_corner" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12182,7 +12182,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_wood_door" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_wood_door" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_wood_door" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12200,7 +12200,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_wood_double_slit_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_wood_double_slit_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_wood_double_slit_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12218,7 +12218,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_wood_floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_wood_floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_wood_floor_/_roof" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12236,7 +12236,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_wood_foundation" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_wood_foundation" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_wood_foundation" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12254,7 +12254,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_wood_slit_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_wood_slit_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_wood_slit_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12272,7 +12272,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_wood_wall_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_wood_wall_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_wood_wall_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12290,7 +12290,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/heavy_wood_wall_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/heavy_wood_wall_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/heavy_wood_wall_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12308,7 +12308,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hellfire" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hellfire" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hellfire" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12326,7 +12326,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hellfire_bolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hellfire_bolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hellfire_bolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12344,7 +12344,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12362,7 +12362,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12380,7 +12380,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12398,7 +12398,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12416,7 +12416,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12434,7 +12434,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12452,7 +12452,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12470,7 +12470,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12488,7 +12488,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12506,7 +12506,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12524,7 +12524,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12542,7 +12542,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12560,7 +12560,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12578,7 +12578,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12596,7 +12596,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12614,7 +12614,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12632,7 +12632,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12650,7 +12650,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12668,7 +12668,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12686,7 +12686,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12704,7 +12704,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12722,7 +12722,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12740,7 +12740,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12758,7 +12758,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12776,7 +12776,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12794,7 +12794,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12812,7 +12812,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12830,7 +12830,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12848,7 +12848,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12866,7 +12866,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hercul_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hercul_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hercul_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12884,7 +12884,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hide" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hide" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hide" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12902,7 +12902,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hollowbone" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hollowbone" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hollowbone" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12920,7 +12920,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/holy_fire" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/holy_fire" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/holy_fire" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12938,7 +12938,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12956,7 +12956,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12974,7 +12974,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -12992,7 +12992,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13010,7 +13010,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13028,7 +13028,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13046,7 +13046,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13064,7 +13064,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13082,7 +13082,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13100,7 +13100,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13118,7 +13118,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13136,7 +13136,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13154,7 +13154,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13172,7 +13172,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13190,7 +13190,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13208,7 +13208,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13226,7 +13226,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13244,7 +13244,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13262,7 +13262,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13280,7 +13280,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13298,7 +13298,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13316,7 +13316,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13334,7 +13334,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13352,7 +13352,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13370,7 +13370,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13388,7 +13388,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13406,7 +13406,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13424,7 +13424,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13442,7 +13442,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13460,7 +13460,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13478,7 +13478,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13496,7 +13496,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13514,7 +13514,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13532,7 +13532,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13550,7 +13550,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13568,7 +13568,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13586,7 +13586,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13604,7 +13604,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13622,7 +13622,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13640,7 +13640,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13658,7 +13658,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13676,7 +13676,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13694,7 +13694,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13712,7 +13712,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13730,7 +13730,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13748,7 +13748,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hornet_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hornet_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hornet_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13766,7 +13766,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hose_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hose_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hose_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13784,7 +13784,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/huge_cactus_fruit" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/huge_cactus_fruit" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/huge_cactus_fruit" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13802,7 +13802,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hullbreaker_scattershot" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hullbreaker_scattershot" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hullbreaker_scattershot" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13820,7 +13820,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/human_sling" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/human_sling" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/human_sling" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13838,7 +13838,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/humidity" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/humidity" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/humidity" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13856,7 +13856,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/hurler_firebomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/hurler_firebomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/hurler_firebomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13874,7 +13874,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_armors" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_armors" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_armors" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13892,7 +13892,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_armors_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_armors_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_armors_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13910,7 +13910,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_capital_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_capital_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_capital_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13928,7 +13928,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_constructions" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_constructions" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_constructions" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13946,7 +13946,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_constructions_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_constructions_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_constructions_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13964,7 +13964,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_crafting_stations_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_crafting_stations_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_crafting_stations_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -13982,7 +13982,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_equipment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_equipment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_equipment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14000,7 +14000,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_large_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_large_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_large_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14018,7 +14018,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_medium_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_medium_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_medium_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14036,7 +14036,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_potions" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_potions" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_potions" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14054,7 +14054,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_small_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_small_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_small_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14072,7 +14072,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_tools" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_tools" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_tools" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14090,7 +14090,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_tools_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_tools_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_tools_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14108,7 +14108,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_walker_parts" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_walker_parts" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_walker_parts" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14126,7 +14126,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_walker_parts_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_walker_parts_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_walker_parts_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14144,7 +14144,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_walker_weapons" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_walker_weapons" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_walker_weapons" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14162,7 +14162,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_walker_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_walker_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_walker_weapons_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14180,7 +14180,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_walkers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_walkers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_walkers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14198,7 +14198,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_weapons" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_weapons" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_weapons" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14216,7 +14216,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improved_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improved_weapons_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improved_weapons_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14234,7 +14234,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/improvised_bottle" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/improvised_bottle" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/improvised_bottle" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14252,7 +14252,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/infused_obsidian_bottle" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/infused_obsidian_bottle" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/infused_obsidian_bottle" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14270,7 +14270,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/infused_pickaxe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/infused_pickaxe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/infused_pickaxe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14288,7 +14288,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/infused_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/infused_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/infused_repair_hammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14306,7 +14306,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/infused_scythe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/infused_scythe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/infused_scythe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14324,7 +14324,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/insect_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/insect_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/insect_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14342,7 +14342,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/insects" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/insects" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/insects" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14360,7 +14360,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/interactables" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/interactables" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/interactables" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14378,7 +14378,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_dart" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_dart" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_dart" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14396,7 +14396,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_gear" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_gear" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_gear" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14414,7 +14414,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_ingot" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_ingot" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_ingot" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14432,7 +14432,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_nails" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_nails" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_nails" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14450,7 +14450,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_ore" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_ore" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_ore" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14468,7 +14468,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_pickaxe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_pickaxe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_pickaxe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14486,7 +14486,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_repair_hammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14504,7 +14504,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_rok" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_rok" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_rok" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14522,7 +14522,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_scythe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_scythe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_scythe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14540,7 +14540,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_studded_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_studded_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_studded_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14558,7 +14558,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_studded_boots" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_studded_boots" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_studded_boots" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14576,7 +14576,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron_studded_gauntlets" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron_studded_gauntlets" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron_studded_gauntlets" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14594,7 +14594,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron-tipped_bolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron-tipped_bolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron-tipped_bolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14612,7 +14612,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/iron-tipped_harpoon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/iron-tipped_harpoon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/iron-tipped_harpoon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14630,7 +14630,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ironblade_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ironblade_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ironblade_quarterstaff" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14648,7 +14648,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/jaggertooth_club" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/jaggertooth_club" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/jaggertooth_club" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14666,7 +14666,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/jaggertooth_maul" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/jaggertooth_maul" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/jaggertooth_maul" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14684,7 +14684,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/jaggertooth_swordclub" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/jaggertooth_swordclub" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/jaggertooth_swordclub" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14702,7 +14702,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/jojo_mojo" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/jojo_mojo" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/jojo_mojo" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14720,7 +14720,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/kaval" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/kaval" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/kaval" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14738,7 +14738,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/kite" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/kite" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/kite" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14756,7 +14756,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/knowledge" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/knowledge" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/knowledge" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14774,7 +14774,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lamp_double_hanging" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lamp_double_hanging" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lamp_double_hanging" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14792,7 +14792,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lamp_overhanging" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lamp_overhanging" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lamp_overhanging" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14810,7 +14810,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lamp_single_hanging" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lamp_single_hanging" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lamp_single_hanging" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14828,7 +14828,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lamp_standing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lamp_standing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lamp_standing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14846,7 +14846,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/large_base_walker_packer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/large_base_walker_packer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/large_base_walker_packer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14864,7 +14864,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/large_chest" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/large_chest" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/large_chest" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14882,7 +14882,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/large_gathering_pouch" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/large_gathering_pouch" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/large_gathering_pouch" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14900,7 +14900,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/large_spare_parts_profile" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/large_spare_parts_profile" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/large_spare_parts_profile" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14918,7 +14918,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/large_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/large_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/large_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14936,7 +14936,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/large_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/large_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/large_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14954,7 +14954,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/large_water_bag" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/large_water_bag" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/large_water_bag" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14972,7 +14972,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/large_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/large_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/large_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -14990,7 +14990,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lathe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lathe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lathe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15008,7 +15008,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lava" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lava" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lava" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15026,7 +15026,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lava_fuel" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lava_fuel" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lava_fuel" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15044,7 +15044,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lava_poppy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lava_poppy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lava_poppy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15062,7 +15062,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lavaliquids" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lavaliquids" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lavaliquids" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15080,7 +15080,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/leather" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/leather" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/leather" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15098,7 +15098,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/legendary" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/legendary" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/legendary" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15116,7 +15116,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lever" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lever" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lever" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15134,7 +15134,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lifeforce_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lifeforce_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lifeforce_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15152,7 +15152,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/light_backpack" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/light_backpack" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/light_backpack" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15170,7 +15170,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/light_javelin" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/light_javelin" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/light_javelin" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15188,7 +15188,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/light_wood_abstract_foundation" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/light_wood_abstract_foundation" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/light_wood_abstract_foundation" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15206,7 +15206,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/light_wood_abstract_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/light_wood_abstract_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/light_wood_abstract_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15224,7 +15224,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/light_wood_guard_rail" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/light_wood_guard_rail" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/light_wood_guard_rail" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15242,7 +15242,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/light_wood_scaffolding" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/light_wood_scaffolding" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/light_wood_scaffolding" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15260,7 +15260,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/light_wood_walker_gate" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/light_wood_walker_gate" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/light_wood_walker_gate" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15278,7 +15278,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lightwood" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lightwood" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lightwood" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15296,7 +15296,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/liquids" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/liquids" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/liquids" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15314,7 +15314,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lobber" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lobber" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lobber" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15332,7 +15332,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/long_bonespike_swordstaff" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/long_bonespike_swordstaff" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/long_bonespike_swordstaff" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15350,7 +15350,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/long_ceramic_hoofmace" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/long_ceramic_hoofmace" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/long_ceramic_hoofmace" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15368,7 +15368,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/long_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/long_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/long_grappling_hook" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15386,7 +15386,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/long_sawblade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/long_sawblade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/long_sawblade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15404,7 +15404,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lumberjack_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lumberjack_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lumberjack_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15422,7 +15422,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/lumbermill" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/lumbermill" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/lumbermill" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15440,7 +15440,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/magma_seeds" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/magma_seeds" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/magma_seeds" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15458,7 +15458,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/maintenance_box" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/maintenance_box" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/maintenance_box" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15476,7 +15476,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/maintenance_vault" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/maintenance_vault" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/maintenance_vault" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15494,7 +15494,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/makeshift_bottle" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/makeshift_bottle" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/makeshift_bottle" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15512,7 +15512,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/makeshift_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/makeshift_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/makeshift_grappling_hook" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15530,7 +15530,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mask_and_eyepatch" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mask_and_eyepatch" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mask_and_eyepatch" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15548,7 +15548,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/masked_totem_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/masked_totem_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/masked_totem_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15566,7 +15566,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/masked_totem_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/masked_totem_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/masked_totem_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15584,7 +15584,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/masked_totem_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/masked_totem_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/masked_totem_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15602,7 +15602,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/meat_rack" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/meat_rack" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/meat_rack" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15620,7 +15620,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_backpack" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_backpack" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_backpack" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15638,7 +15638,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_chest" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_chest" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_chest" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15656,7 +15656,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_spare_parts_profile" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_spare_parts_profile" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_spare_parts_profile" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15674,7 +15674,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_stinger" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_stinger" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_stinger" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15692,7 +15692,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15710,7 +15710,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15728,7 +15728,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_water_bag" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_water_bag" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_water_bag" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15746,7 +15746,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15764,7 +15764,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_wood_battlements" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_wood_battlements" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_wood_battlements" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15782,7 +15782,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_wood_door" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_wood_door" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_wood_door" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15800,7 +15800,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_wood_double_slit_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_wood_double_slit_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_wood_double_slit_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15818,7 +15818,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_wood_floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_wood_floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_wood_floor_/_roof" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15836,7 +15836,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_wood_foundation" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_wood_foundation" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_wood_foundation" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15854,7 +15854,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_wood_slit_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_wood_slit_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_wood_slit_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15872,7 +15872,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_wood_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_wood_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_wood_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15890,7 +15890,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/medium_wood_walls" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/medium_wood_walls" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/medium_wood_walls" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15908,7 +15908,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/merchant_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/merchant_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/merchant_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15926,7 +15926,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/meteor_core" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/meteor_core" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/meteor_core" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15944,7 +15944,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mobility_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mobility_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mobility_-_tier_1_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15962,7 +15962,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mobility_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mobility_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mobility_-_tier_2_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15980,7 +15980,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mobility_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mobility_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mobility_-_tier_3_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -15998,7 +15998,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mobility_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mobility_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mobility_-_tier_4_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16016,7 +16016,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/modules_strongbox" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/modules_strongbox" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/modules_strongbox" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16034,7 +16034,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16052,7 +16052,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16070,7 +16070,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16088,7 +16088,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16106,7 +16106,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16124,7 +16124,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16142,7 +16142,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16160,7 +16160,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16178,7 +16178,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16196,7 +16196,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16214,7 +16214,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16232,7 +16232,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16250,7 +16250,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16268,7 +16268,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16286,7 +16286,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16304,7 +16304,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16322,7 +16322,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16340,7 +16340,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16358,7 +16358,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16376,7 +16376,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16394,7 +16394,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16412,7 +16412,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16430,7 +16430,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16448,7 +16448,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16466,7 +16466,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16484,7 +16484,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16502,7 +16502,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16520,7 +16520,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16538,7 +16538,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16556,7 +16556,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16574,7 +16574,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16592,7 +16592,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16610,7 +16610,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16628,7 +16628,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16646,7 +16646,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16664,7 +16664,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16682,7 +16682,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16700,7 +16700,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16718,7 +16718,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16736,7 +16736,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16754,7 +16754,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16772,7 +16772,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16790,7 +16790,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16808,7 +16808,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mollusk_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mollusk_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mollusk_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16826,7 +16826,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mountable_nurr" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mountable_nurr" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mountable_nurr" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16844,7 +16844,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/mushroom_flesh" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/mushroom_flesh" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/mushroom_flesh" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16862,7 +16862,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/musical_instruments" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/musical_instruments" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/musical_instruments" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16880,7 +16880,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/net" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/net" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/net" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16898,7 +16898,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/net_pouch" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/net_pouch" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/net_pouch" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16916,7 +16916,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/net_thrower" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/net_thrower" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/net_thrower" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16934,7 +16934,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibiran_battle_axe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibiran_battle_axe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibiran_battle_axe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16952,7 +16952,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibiran_curved_dagger" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibiran_curved_dagger" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibiran_curved_dagger" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16970,7 +16970,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibiran_decapitator" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibiran_decapitator" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibiran_decapitator" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -16988,7 +16988,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibiran_hammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibiran_hammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibiran_hammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17006,7 +17006,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibiran_hand_axe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibiran_hand_axe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibiran_hand_axe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17024,7 +17024,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibiran_ingot" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibiran_ingot" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibiran_ingot" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17042,7 +17042,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibiran_mineral" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibiran_mineral" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibiran_mineral" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17060,7 +17060,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibiran_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibiran_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibiran_quarterstaff" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17078,7 +17078,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibiran_warhammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibiran_warhammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibiran_warhammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17096,7 +17096,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibiran-tipped_bolt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibiran-tipped_bolt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibiran-tipped_bolt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17114,7 +17114,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibirian_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibirian_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibirian_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17132,7 +17132,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibirian_boots" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibirian_boots" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibirian_boots" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17150,7 +17150,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibirian_dart" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibirian_dart" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibirian_dart" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17168,7 +17168,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibirian_gauntlets" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibirian_gauntlets" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibirian_gauntlets" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17186,7 +17186,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nibirian_harpoon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nibirian_harpoon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nibirian_harpoon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17204,7 +17204,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nomad_cloth" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nomad_cloth" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nomad_cloth" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17222,7 +17222,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nomad_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nomad_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nomad_grappling_hook" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17240,7 +17240,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nurr_fang" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nurr_fang" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nurr_fang" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17258,7 +17258,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nurrfang_maul" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nurrfang_maul" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nurrfang_maul" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17276,7 +17276,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/nurrfang_toothclub" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/nurrfang_toothclub" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/nurrfang_toothclub" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17294,7 +17294,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/obsidian" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/obsidian" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/obsidian" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17312,7 +17312,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/obsidian_canister" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/obsidian_canister" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/obsidian_canister" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17330,7 +17330,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/obsidian_flask" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/obsidian_flask" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/obsidian_flask" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17348,7 +17348,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/obsidian_machine" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/obsidian_machine" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/obsidian_machine" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17366,7 +17366,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/obsidian_pot" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/obsidian_pot" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/obsidian_pot" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17384,7 +17384,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/obsidian_rok" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/obsidian_rok" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/obsidian_rok" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17402,7 +17402,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/okkam_statue_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/okkam_statue_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/okkam_statue_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17420,7 +17420,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/okkam_statue_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/okkam_statue_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/okkam_statue_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17438,7 +17438,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ornate_banner_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ornate_banner_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ornate_banner_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17456,7 +17456,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ornate_banner_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ornate_banner_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ornate_banner_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17474,7 +17474,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ornate_banner_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ornate_banner_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ornate_banner_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17492,7 +17492,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ornate_veil_cap" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ornate_veil_cap" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ornate_veil_cap" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17510,7 +17510,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/oud" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/oud" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/oud" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17528,7 +17528,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/pack_mule_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/pack_mule_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/pack_mule_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17546,7 +17546,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/pack_speed_base_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/pack_speed_base_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/pack_speed_base_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17564,7 +17564,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/pack_speed_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/pack_speed_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/pack_speed_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17582,7 +17582,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/packing_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/packing_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/packing_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17600,7 +17600,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/paddleblade_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/paddleblade_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/paddleblade_quarterstaff" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17618,7 +17618,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/palm_leaves" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/palm_leaves" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/palm_leaves" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17636,7 +17636,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17654,7 +17654,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17672,7 +17672,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17690,7 +17690,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17708,7 +17708,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17726,7 +17726,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17744,7 +17744,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17762,7 +17762,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17780,7 +17780,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17798,7 +17798,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17816,7 +17816,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17834,7 +17834,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17852,7 +17852,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17870,7 +17870,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17888,7 +17888,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17906,7 +17906,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17924,7 +17924,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17942,7 +17942,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17960,7 +17960,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17978,7 +17978,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -17996,7 +17996,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18014,7 +18014,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18032,7 +18032,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18050,7 +18050,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18068,7 +18068,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18086,7 +18086,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18104,7 +18104,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18122,7 +18122,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18140,7 +18140,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18158,7 +18158,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18176,7 +18176,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18194,7 +18194,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18212,7 +18212,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18230,7 +18230,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18248,7 +18248,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18266,7 +18266,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18284,7 +18284,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18302,7 +18302,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18320,7 +18320,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18338,7 +18338,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18356,7 +18356,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18374,7 +18374,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18392,7 +18392,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18410,7 +18410,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18428,7 +18428,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18446,7 +18446,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/panda_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/panda_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/panda_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18464,7 +18464,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/pearl" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/pearl" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/pearl" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18482,7 +18482,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/pedestal_chest" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/pedestal_chest" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/pedestal_chest" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18500,7 +18500,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/penetrating_dart" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/penetrating_dart" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/penetrating_dart" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18518,7 +18518,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/phosphorus" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/phosphorus" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/phosphorus" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18536,7 +18536,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/pine_tree" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/pine_tree" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/pine_tree" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18554,7 +18554,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/poaching_hut" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/poaching_hut" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/poaching_hut" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18572,7 +18572,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/podium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/podium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/podium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18590,7 +18590,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/premade_throne" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/premade_throne" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/premade_throne" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18608,7 +18608,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/primitive_bandage" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/primitive_bandage" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/primitive_bandage" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18626,7 +18626,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_license" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_license" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_license" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18644,7 +18644,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18662,7 +18662,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18680,7 +18680,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18698,7 +18698,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18716,7 +18716,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18734,7 +18734,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18752,7 +18752,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18770,7 +18770,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18788,7 +18788,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18806,7 +18806,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/proxy_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/proxy_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/proxy_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18824,7 +18824,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/purification_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/purification_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/purification_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18842,7 +18842,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/purified_water" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/purified_water" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/purified_water" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18860,7 +18860,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/quarry" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/quarry" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/quarry" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18878,7 +18878,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/race_dust" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/race_dust" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/race_dust" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18896,7 +18896,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rag" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rag" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rag" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18914,7 +18914,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raider_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raider_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raider_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18932,7 +18932,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/random_knowledge_tablet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/random_knowledge_tablet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/random_knowledge_tablet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18950,7 +18950,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rangefinder" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rangefinder" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rangefinder" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18968,7 +18968,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -18986,7 +18986,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19004,7 +19004,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19022,7 +19022,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19040,7 +19040,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19058,7 +19058,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19076,7 +19076,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19094,7 +19094,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19112,7 +19112,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19130,7 +19130,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19148,7 +19148,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19166,7 +19166,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19184,7 +19184,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19202,7 +19202,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19220,7 +19220,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19238,7 +19238,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19256,7 +19256,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19274,7 +19274,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19292,7 +19292,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19310,7 +19310,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19328,7 +19328,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19346,7 +19346,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19364,7 +19364,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19382,7 +19382,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19400,7 +19400,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19418,7 +19418,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19436,7 +19436,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19454,7 +19454,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19472,7 +19472,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19490,7 +19490,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19508,7 +19508,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19526,7 +19526,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19544,7 +19544,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/raptor_sky_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/raptor_sky_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/raptor_sky_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19562,7 +19562,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rare" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rare" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rare" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19580,7 +19580,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rawbone_battle_axe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rawbone_battle_axe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rawbone_battle_axe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19598,7 +19598,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rawbone_club" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rawbone_club" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rawbone_club" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19616,7 +19616,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rawbone_hand_axe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rawbone_hand_axe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rawbone_hand_axe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19634,7 +19634,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rawbone_maul" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rawbone_maul" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rawbone_maul" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19652,7 +19652,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rawbone_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rawbone_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rawbone_quarterstaff" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19670,7 +19670,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rawbone_sawsword" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rawbone_sawsword" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rawbone_sawsword" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19688,7 +19688,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/red_banana" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/red_banana" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/red_banana" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19706,7 +19706,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/redwood_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/redwood_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/redwood_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19724,7 +19724,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/redwood_boots" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/redwood_boots" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/redwood_boots" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19742,7 +19742,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/redwood_sleeves" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/redwood_sleeves" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/redwood_sleeves" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19760,7 +19760,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/redwood_wood" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/redwood_wood" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/redwood_wood" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19778,7 +19778,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/reinforced_gear" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/reinforced_gear" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/reinforced_gear" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19796,7 +19796,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/reinforced_plank" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/reinforced_plank" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/reinforced_plank" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19814,7 +19814,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/reinforced_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/reinforced_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/reinforced_walls_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19832,7 +19832,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/relic_of_dawn" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/relic_of_dawn" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/relic_of_dawn" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19850,7 +19850,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/relic_of_dusk" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/relic_of_dusk" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/relic_of_dusk" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19868,7 +19868,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/relic_of_the_stars" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/relic_of_the_stars" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/relic_of_the_stars" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19886,7 +19886,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/repair_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/repair_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/repair_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19904,7 +19904,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/repaired_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/repaired_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/repaired_grappling_hook" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19922,7 +19922,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/repeater" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/repeater" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/repeater" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19940,7 +19940,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/resources" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/resources" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/resources" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19958,7 +19958,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rokker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rokker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rokker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19976,7 +19976,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/roofing_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/roofing_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/roofing_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -19994,7 +19994,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/roofing_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/roofing_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/roofing_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20012,7 +20012,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rope" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rope" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rope" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20030,7 +20030,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rubab" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rubab" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rubab" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20048,7 +20048,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rubber_block" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rubber_block" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rubber_block" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20066,7 +20066,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/ruffian_mask" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/ruffian_mask" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/ruffian_mask" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20084,7 +20084,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rugged_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rugged_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rugged_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20102,7 +20102,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_bomb_javelin" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_bomb_javelin" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_bomb_javelin" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20120,7 +20120,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_bone_javelin" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_bone_javelin" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_bone_javelin" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20138,7 +20138,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_campfire_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_campfire_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_campfire_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20156,7 +20156,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_campfire_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_campfire_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_campfire_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20174,7 +20174,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_dart" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_dart" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_dart" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20192,7 +20192,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_desolator_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_desolator_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_desolator_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20210,7 +20210,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_drudge_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_drudge_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_drudge_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20228,7 +20228,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_dunestalker_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_dunestalker_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_dunestalker_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20246,7 +20246,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_firebrand_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_firebrand_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_firebrand_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20264,7 +20264,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_forager_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_forager_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_forager_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20282,7 +20282,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_forerunner_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_forerunner_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_forerunner_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20300,7 +20300,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_fur_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_fur_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_fur_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20318,7 +20318,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_fur_sandals" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_fur_sandals" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_fur_sandals" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20336,7 +20336,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_fur_sleeves" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_fur_sleeves" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_fur_sleeves" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20354,7 +20354,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_gel" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_gel" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_gel" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20372,7 +20372,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_harasser_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_harasser_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_harasser_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20390,7 +20390,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_hazraki_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_hazraki_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_hazraki_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20408,7 +20408,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_mace" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_mace" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_mace" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20426,7 +20426,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_mask" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_mask" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_mask" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20444,7 +20444,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_pelt" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_pelt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_pelt" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20462,7 +20462,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_plainstrider_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_plainstrider_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_plainstrider_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20480,7 +20480,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_prophet_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_prophet_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_prophet_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20498,7 +20498,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_repellent" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_repellent" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_repellent" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20516,7 +20516,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_rock" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_rock" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_rock" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20534,7 +20534,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_rok" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_rok" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_rok" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20552,7 +20552,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_sentinel_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_sentinel_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_sentinel_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20570,7 +20570,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_shaman_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_shaman_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_shaman_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20588,7 +20588,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_skirmisher_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_skirmisher_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_skirmisher_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20606,7 +20606,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_sling" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_sling" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_sling" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20624,7 +20624,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_stone_bolas" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_stone_bolas" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_stone_bolas" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20642,7 +20642,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_stone_mace" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_stone_mace" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_stone_mace" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20660,7 +20660,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_throwstone" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_throwstone" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_throwstone" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20678,7 +20678,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_thug_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_thug_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_thug_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20696,7 +20696,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/rupu_vine" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/rupu_vine" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/rupu_vine" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20714,7 +20714,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/salt_rock" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/salt_rock" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/salt_rock" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20732,7 +20732,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20750,7 +20750,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand_bed" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand_bed" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand_bed" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20768,7 +20768,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand_cloth_door" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand_cloth_door" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand_cloth_door" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20786,7 +20786,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand_sand_foundation" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand_sand_foundation" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand_sand_foundation" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20804,7 +20804,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand_sand_ramp" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand_sand_ramp" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand_sand_ramp" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20822,7 +20822,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand_sandbag_gate" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand_sandbag_gate" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand_sandbag_gate" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20840,7 +20840,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand_sandbag_roof" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand_sandbag_roof" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand_sandbag_roof" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20858,7 +20858,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand_sandbag_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand_sandbag_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand_sandbag_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20876,7 +20876,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand_sandbag_wall_window" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand_sandbag_wall_window" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand_sandbag_wall_window" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20894,7 +20894,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand_structures" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand_structures" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand_structures" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20912,7 +20912,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sand_structures_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sand_structures_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sand_structures_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20930,7 +20930,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sandy_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sandy_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sandy_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20948,7 +20948,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sawblade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sawblade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sawblade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20966,7 +20966,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/scattershot_ammo" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/scattershot_ammo" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/scattershot_ammo" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -20984,7 +20984,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/scattershot_gun" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/scattershot_gun" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/scattershot_gun" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21002,7 +21002,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/scavenger_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/scavenger_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/scavenger_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21020,7 +21020,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schematic_bag" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schematic_bag" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schematic_bag" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21038,7 +21038,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21056,7 +21056,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21074,7 +21074,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21092,7 +21092,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21110,7 +21110,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21128,7 +21128,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21146,7 +21146,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21164,7 +21164,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21182,7 +21182,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21200,7 +21200,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21218,7 +21218,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21236,7 +21236,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21254,7 +21254,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21272,7 +21272,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21290,7 +21290,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21308,7 +21308,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21326,7 +21326,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21344,7 +21344,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21362,7 +21362,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21380,7 +21380,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21398,7 +21398,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21416,7 +21416,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21434,7 +21434,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21452,7 +21452,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21470,7 +21470,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21488,7 +21488,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21506,7 +21506,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21524,7 +21524,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21542,7 +21542,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21560,7 +21560,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21578,7 +21578,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21596,7 +21596,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21614,7 +21614,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21632,7 +21632,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21650,7 +21650,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21668,7 +21668,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21686,7 +21686,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21704,7 +21704,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21722,7 +21722,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21740,7 +21740,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21758,7 +21758,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21776,7 +21776,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21794,7 +21794,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21812,7 +21812,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21830,7 +21830,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21848,7 +21848,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/schmetterling_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/schmetterling_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/schmetterling_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21866,7 +21866,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/scroll_rack" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/scroll_rack" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/scroll_rack" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21884,7 +21884,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/scythe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/scythe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/scythe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21902,7 +21902,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/segment_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/segment_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/segment_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21920,7 +21920,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/segment_2_(round)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/segment_2_(round)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/segment_2_(round)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21938,7 +21938,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/segment_3_(round)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/segment_3_(round)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/segment_3_(round)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21956,7 +21956,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/segment_4_(half)" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/segment_4_(half)" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/segment_4_(half)" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21974,7 +21974,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/segment_5" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/segment_5" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/segment_5" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -21992,7 +21992,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/shackle" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/shackle" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/shackle" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22010,7 +22010,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/shardrock" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/shardrock" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/shardrock" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22028,7 +22028,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sharp_spikes" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sharp_spikes" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sharp_spikes" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22046,7 +22046,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/shattered_fragment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/shattered_fragment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/shattered_fragment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22064,7 +22064,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/shop_masks" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/shop_masks" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/shop_masks" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22082,7 +22082,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/short_ceramic_hoofmace" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/short_ceramic_hoofmace" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/short_ceramic_hoofmace" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22100,7 +22100,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/short_malletblade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/short_malletblade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/short_malletblade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22118,7 +22118,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22136,7 +22136,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22154,7 +22154,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22172,7 +22172,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22190,7 +22190,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22208,7 +22208,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22226,7 +22226,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22244,7 +22244,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22262,7 +22262,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22280,7 +22280,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22298,7 +22298,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22316,7 +22316,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22334,7 +22334,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22352,7 +22352,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/silur_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/silur_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/silur_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22370,7 +22370,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/simple_pickaxe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/simple_pickaxe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/simple_pickaxe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22388,7 +22388,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/simple_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/simple_repair_hammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/simple_repair_hammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22406,7 +22406,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/simple_sickle" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/simple_sickle" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/simple_sickle" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22424,7 +22424,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/singblade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/singblade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/singblade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22442,7 +22442,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sinus_destroyer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sinus_destroyer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sinus_destroyer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22460,7 +22460,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/skirmish_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/skirmish_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/skirmish_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22478,7 +22478,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/slingshot" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/slingshot" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/slingshot" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22496,7 +22496,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/slit_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/slit_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/slit_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22514,7 +22514,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_base_walker_packer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_base_walker_packer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_base_walker_packer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22532,7 +22532,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_boulder" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_boulder" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_boulder" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22550,7 +22550,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_chest" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_chest" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_chest" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22568,7 +22568,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_repair_hoist" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_repair_hoist" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_repair_hoist" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22586,7 +22586,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_rope_ladder" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_rope_ladder" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_rope_ladder" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22604,7 +22604,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_scattershot_gun" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_scattershot_gun" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_scattershot_gun" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22622,7 +22622,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_spare_parts_profile" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_spare_parts_profile" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_spare_parts_profile" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22640,7 +22640,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_walker_leg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_walker_leg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_walker_leg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22658,7 +22658,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22676,7 +22676,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_walker_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_walker_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_walker_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22694,7 +22694,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22712,7 +22712,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_water_bag" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_water_bag" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_water_bag" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22730,7 +22730,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/small_wing" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/small_wing" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/small_wing" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22748,7 +22748,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/soil_excavator" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/soil_excavator" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/soil_excavator" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22766,7 +22766,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spare_parts" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spare_parts" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spare_parts" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22784,7 +22784,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spearmint" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spearmint" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spearmint" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22802,7 +22802,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22820,7 +22820,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22838,7 +22838,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22856,7 +22856,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22874,7 +22874,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22892,7 +22892,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22910,7 +22910,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22928,7 +22928,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22946,7 +22946,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22964,7 +22964,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -22982,7 +22982,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23000,7 +23000,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23018,7 +23018,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23036,7 +23036,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23054,7 +23054,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23072,7 +23072,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23090,7 +23090,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23108,7 +23108,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23126,7 +23126,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23144,7 +23144,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23162,7 +23162,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23180,7 +23180,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23198,7 +23198,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23216,7 +23216,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23234,7 +23234,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23252,7 +23252,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23270,7 +23270,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23288,7 +23288,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23306,7 +23306,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spider_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spider_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spider_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23324,7 +23324,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spinner" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spinner" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spinner" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23342,7 +23342,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spline" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spline" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spline" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23360,7 +23360,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/split_bone_bottle" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/split_bone_bottle" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/split_bone_bottle" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23378,7 +23378,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/split_ceramic_flask" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/split_ceramic_flask" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/split_ceramic_flask" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23396,7 +23396,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/split_durable_water_sack" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/split_durable_water_sack" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/split_durable_water_sack" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23414,7 +23414,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spring" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spring" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spring" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23432,7 +23432,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/spring_spikes_trap" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/spring_spikes_trap" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/spring_spikes_trap" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23450,7 +23450,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/squared_eyepatches" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/squared_eyepatches" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/squared_eyepatches" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23468,7 +23468,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stairs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stairs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stairs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23486,7 +23486,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stairs_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stairs_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stairs_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23504,7 +23504,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stairs_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stairs_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stairs_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23522,7 +23522,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stairs_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stairs_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stairs_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23540,7 +23540,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/starch_cement" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/starch_cement" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/starch_cement" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23558,7 +23558,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/steering_levers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/steering_levers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/steering_levers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23576,7 +23576,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/steering_levers_cage" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/steering_levers_cage" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/steering_levers_cage" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23594,7 +23594,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sterile_bandage" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sterile_bandage" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sterile_bandage" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23612,7 +23612,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23630,7 +23630,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23648,7 +23648,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23666,7 +23666,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23684,7 +23684,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23702,7 +23702,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23720,7 +23720,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23738,7 +23738,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23756,7 +23756,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23774,7 +23774,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23792,7 +23792,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23810,7 +23810,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23828,7 +23828,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23846,7 +23846,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23864,7 +23864,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23882,7 +23882,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23900,7 +23900,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23918,7 +23918,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23936,7 +23936,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23954,7 +23954,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23972,7 +23972,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -23990,7 +23990,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24008,7 +24008,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24026,7 +24026,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24044,7 +24044,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24062,7 +24062,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24080,7 +24080,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24098,7 +24098,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24116,7 +24116,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24134,7 +24134,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24152,7 +24152,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24170,7 +24170,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24188,7 +24188,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24206,7 +24206,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24224,7 +24224,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24242,7 +24242,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24260,7 +24260,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24278,7 +24278,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24296,7 +24296,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24314,7 +24314,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24332,7 +24332,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24350,7 +24350,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24368,7 +24368,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24386,7 +24386,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stiletto_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stiletto_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stiletto_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24404,7 +24404,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stinger" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stinger" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stinger" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24422,7 +24422,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stomping_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stomping_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stomping_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24440,7 +24440,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24458,7 +24458,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_axe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_axe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_axe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24476,7 +24476,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_door" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_door" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_door" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24494,7 +24494,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_floor_/_roof" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_floor_/_roof" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24512,7 +24512,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_foundation" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_foundation" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_foundation" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24530,7 +24530,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_humidifier" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_humidifier" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_humidifier" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24548,7 +24548,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_monkey_sword" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_monkey_sword" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_monkey_sword" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24566,7 +24566,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_plank" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_plank" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_plank" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24584,7 +24584,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24602,7 +24602,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_wall_with_window" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_wall_with_window" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_wall_with_window" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24620,7 +24620,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_walls" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_walls" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_walls" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24638,7 +24638,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/stone_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/stone_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/stone_walls_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24656,7 +24656,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/structure_hardening_base_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/structure_hardening_base_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/structure_hardening_base_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24674,7 +24674,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/strut" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/strut" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/strut" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24692,7 +24692,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sturdy_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sturdy_grappling_hook" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sturdy_grappling_hook" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24710,7 +24710,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sulfur" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sulfur" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sulfur" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24728,7 +24728,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sulfur_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sulfur_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sulfur_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24746,7 +24746,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sun_ray_burner" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sun_ray_burner" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sun_ray_burner" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24764,7 +24764,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/sunset_headdress" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/sunset_headdress" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/sunset_headdress" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24782,7 +24782,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/super_cluster_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/super_cluster_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/super_cluster_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24800,7 +24800,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/swampwood_galoshes" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/swampwood_galoshes" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/swampwood_galoshes" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24818,7 +24818,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/table" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/table" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/table" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24836,7 +24836,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tablet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tablet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tablet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24854,7 +24854,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tall_stinger" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tall_stinger" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tall_stinger" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24872,7 +24872,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tallow" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tallow" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tallow" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24890,7 +24890,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tambourine" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tambourine" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tambourine" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24908,7 +24908,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tar" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tar" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tar" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24926,7 +24926,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/terrain:_asteroid_crash_site" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/terrain:_asteroid_crash_site" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/terrain:_asteroid_crash_site" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24944,7 +24944,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/terrain:_black_soil" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/terrain:_black_soil" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/terrain:_black_soil" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24962,7 +24962,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/terrain:_clay_spots" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/terrain:_clay_spots" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/terrain:_clay_spots" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24980,7 +24980,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/terrain:_excavatable" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/terrain:_excavatable" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/terrain:_excavatable" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -24998,7 +24998,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/terrain:_salt_flats" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/terrain:_salt_flats" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/terrain:_salt_flats" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25016,7 +25016,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/terrain:_sand" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/terrain:_sand" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/terrain:_sand" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25034,7 +25034,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/terrain:_worm_sand" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/terrain:_worm_sand" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/terrain:_worm_sand" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25052,7 +25052,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/thornberry" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/thornberry" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/thornberry" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25070,7 +25070,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/throne" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/throne" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/throne" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25088,7 +25088,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/throwable_aloe_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/throwable_aloe_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/throwable_aloe_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25106,7 +25106,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/throwable_insect_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/throwable_insect_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/throwable_insect_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25124,7 +25124,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/throwable_smoke_bomb" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/throwable_smoke_bomb" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/throwable_smoke_bomb" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25142,7 +25142,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/throwing_net" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/throwing_net" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/throwing_net" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25160,7 +25160,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/throwstone" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/throwstone" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/throwstone" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25178,7 +25178,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/thumper" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/thumper" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/thumper" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25196,7 +25196,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tied_keffiyeh_scarf" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tied_keffiyeh_scarf" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tied_keffiyeh_scarf" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25214,7 +25214,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25232,7 +25232,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25250,7 +25250,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25268,7 +25268,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25286,7 +25286,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25304,7 +25304,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25322,7 +25322,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25340,7 +25340,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25358,7 +25358,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25376,7 +25376,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25394,7 +25394,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25412,7 +25412,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25430,7 +25430,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25448,7 +25448,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25466,7 +25466,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25484,7 +25484,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25502,7 +25502,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25520,7 +25520,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25538,7 +25538,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25556,7 +25556,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25574,7 +25574,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25592,7 +25592,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25610,7 +25610,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25628,7 +25628,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25646,7 +25646,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25664,7 +25664,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25682,7 +25682,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25700,7 +25700,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25718,7 +25718,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25736,7 +25736,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25754,7 +25754,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25772,7 +25772,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25790,7 +25790,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25808,7 +25808,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25826,7 +25826,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25844,7 +25844,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25862,7 +25862,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25880,7 +25880,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25898,7 +25898,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25916,7 +25916,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25934,7 +25934,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25952,7 +25952,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25970,7 +25970,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -25988,7 +25988,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26006,7 +26006,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26024,7 +26024,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/titan_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/titan_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/titan_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26042,7 +26042,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26060,7 +26060,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26078,7 +26078,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26096,7 +26096,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26114,7 +26114,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26132,7 +26132,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26150,7 +26150,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26168,7 +26168,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26186,7 +26186,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26204,7 +26204,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26222,7 +26222,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26240,7 +26240,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26258,7 +26258,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26276,7 +26276,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26294,7 +26294,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26312,7 +26312,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26330,7 +26330,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26348,7 +26348,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26366,7 +26366,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26384,7 +26384,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26402,7 +26402,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26420,7 +26420,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26438,7 +26438,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26456,7 +26456,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26474,7 +26474,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26492,7 +26492,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26510,7 +26510,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26528,7 +26528,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26546,7 +26546,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26564,7 +26564,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26582,7 +26582,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26600,7 +26600,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26618,7 +26618,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26636,7 +26636,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26654,7 +26654,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26672,7 +26672,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26690,7 +26690,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26708,7 +26708,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26726,7 +26726,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26744,7 +26744,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26762,7 +26762,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26780,7 +26780,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26798,7 +26798,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26816,7 +26816,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26834,7 +26834,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26852,7 +26852,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toboggan_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toboggan_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toboggan_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26870,7 +26870,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tool_pod" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tool_pod" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tool_pod" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26888,7 +26888,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tools" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tools" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tools" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26906,7 +26906,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tools_and_equipment_strongbox" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tools_and_equipment_strongbox" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tools_and_equipment_strongbox" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26924,7 +26924,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tools_strongbox" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tools_strongbox" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tools_strongbox" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26942,7 +26942,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/torch" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/torch" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/torch" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26960,7 +26960,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/torque" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/torque" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/torque" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26978,7 +26978,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/torque_backpack" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/torque_backpack" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/torque_backpack" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -26996,7 +26996,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/torque_battery" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/torque_battery" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/torque_battery" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27014,7 +27014,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/torque_capacity_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/torque_capacity_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/torque_capacity_-_tier_1_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27032,7 +27032,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/torque_capacity_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/torque_capacity_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/torque_capacity_-_tier_2_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27050,7 +27050,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/torque_capacity_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/torque_capacity_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/torque_capacity_-_tier_3_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27068,7 +27068,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/torque_capacity_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/torque_capacity_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/torque_capacity_-_tier_4_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27086,7 +27086,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/torque_chest" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/torque_chest" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/torque_chest" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27104,7 +27104,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/torque_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/torque_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/torque_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27122,7 +27122,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/toxic_remains" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/toxic_remains" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/toxic_remains" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27140,7 +27140,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/trap_door" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/trap_door" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/trap_door" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27158,7 +27158,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/traveller%E2%80%99s_staff" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/traveller%E2%80%99s_staff" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/traveller%E2%80%99s_staff" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27176,7 +27176,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/treasure_map" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/treasure_map" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/treasure_map" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27194,7 +27194,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tree_sap" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tree_sap" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tree_sap" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27212,7 +27212,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/trip_wire_trap" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/trip_wire_trap" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/trip_wire_trap" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27230,7 +27230,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/triple_stitch_armor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/triple_stitch_armor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/triple_stitch_armor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27248,7 +27248,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/triple_stitch_boots" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/triple_stitch_boots" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/triple_stitch_boots" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27266,7 +27266,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/triple_stitch_bracers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/triple_stitch_bracers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/triple_stitch_bracers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27284,7 +27284,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/triple_stitch_fabric" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/triple_stitch_fabric" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/triple_stitch_fabric" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27302,7 +27302,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tube_spade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tube_spade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tube_spade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27320,7 +27320,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27338,7 +27338,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_legs" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_legs" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_legs" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27356,7 +27356,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_legs_armored" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_legs_armored" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27374,7 +27374,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_legs_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_legs_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27392,7 +27392,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_rig_t1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_rig_t1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27410,7 +27410,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_rig_t2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_rig_t2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27428,7 +27428,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_rig_t2_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_rig_t2_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27446,7 +27446,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_rig_t3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_rig_t3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27464,7 +27464,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_rig_t3_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_rig_t3_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27482,7 +27482,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27500,7 +27500,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_cargo_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_cargo_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27518,7 +27518,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_cargo_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_cargo_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27536,7 +27536,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_cargo_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_cargo_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27554,7 +27554,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_cargo_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_cargo_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27572,7 +27572,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_durability_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_durability_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27590,7 +27590,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_durability_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_durability_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27608,7 +27608,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_durability_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_durability_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27626,7 +27626,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_durability_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_durability_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27644,7 +27644,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_gear_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_gear_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27662,7 +27662,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_gear_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_gear_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27680,7 +27680,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_gear_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_gear_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27698,7 +27698,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_gear_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_gear_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27716,7 +27716,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_mobility_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_mobility_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27734,7 +27734,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_mobility_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_mobility_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27752,7 +27752,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_mobility_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_mobility_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27770,7 +27770,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_mobility_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_mobility_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27788,7 +27788,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_packing_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_packing_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27806,7 +27806,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_packing_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_packing_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27824,7 +27824,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_packing_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_packing_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27842,7 +27842,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_packing_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_packing_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27860,7 +27860,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_torque_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_torque_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27878,7 +27878,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_torque_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_torque_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27896,7 +27896,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_torque_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_torque_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27914,7 +27914,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_torque_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_torque_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27932,7 +27932,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_water_tier_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_water_tier_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27950,7 +27950,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_water_tier_2" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_water_tier_2" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27968,7 +27968,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_water_tier_3" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_water_tier_3" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -27986,7 +27986,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_upgrade_water_tier_4" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_upgrade_water_tier_4" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28004,7 +28004,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_wings" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_wings" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_wings" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28022,7 +28022,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_wings_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_wings_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28040,7 +28040,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_wings_large" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_wings_large" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28058,7 +28058,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_wings_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_wings_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28076,7 +28076,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_wings_raider" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_wings_raider" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28094,7 +28094,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_wings_rugged" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_wings_rugged" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28112,7 +28112,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_wings_skirmish" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_wings_skirmish" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28130,7 +28130,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/tusker_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/tusker_walker_wings_small" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/tusker_walker_wings_small" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28148,7 +28148,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/uncommon" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/uncommon" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/uncommon" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28166,7 +28166,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/vault" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/vault" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/vault" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28184,7 +28184,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/violin" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/violin" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/violin" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28202,7 +28202,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/vision_powder" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/vision_powder" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/vision_powder" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28220,7 +28220,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/vitamins" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/vitamins" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/vitamins" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28238,7 +28238,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/walker_climber" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/walker_climber" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/walker_climber" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28256,7 +28256,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/walker_hangar" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/walker_hangar" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/walker_hangar" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28274,7 +28274,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/walker_landmine" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/walker_landmine" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/walker_landmine" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28292,7 +28292,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/walker_packing_compartment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/walker_packing_compartment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/walker_packing_compartment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28310,7 +28310,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/walker_parts" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/walker_parts" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/walker_parts" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28328,7 +28328,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/walker_tools" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/walker_tools" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/walker_tools" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28346,7 +28346,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/walker_totem" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/walker_totem" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/walker_totem" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28364,7 +28364,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/walkerrigs_c" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/walkerrigs_c" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/walkerrigs_c" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28382,7 +28382,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/walkers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/walkers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/walkers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28400,7 +28400,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wall" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wall" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wall" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28418,7 +28418,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wall_1" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wall_1" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wall_1" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28436,7 +28436,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wanderer&apos;s_potion" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wanderer&apos;s_potion" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wanderer&apos;s_potion" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28454,7 +28454,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/water_bed" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/water_bed" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/water_bed" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28472,7 +28472,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/water_circulator" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/water_circulator" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/water_circulator" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28490,7 +28490,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/water_condenser" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/water_condenser" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/water_condenser" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28508,7 +28508,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/water_pitcher" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/water_pitcher" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/water_pitcher" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28526,7 +28526,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/water_storage_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/water_storage_-_tier_1_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/water_storage_-_tier_1_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28544,7 +28544,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/water_storage_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/water_storage_-_tier_2_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/water_storage_-_tier_2_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28562,7 +28562,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/water_storage_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/water_storage_-_tier_3_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/water_storage_-_tier_3_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28580,7 +28580,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/water_storage_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/water_storage_-_tier_4_upgrade" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/water_storage_-_tier_4_upgrade" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28598,7 +28598,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/watery_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/watery_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/watery_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28616,7 +28616,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/weapon_shipment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/weapon_shipment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/weapon_shipment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28634,7 +28634,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/weapon_strongbox" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/weapon_strongbox" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/weapon_strongbox" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28652,7 +28652,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/weapons" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/weapons" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/weapons" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28670,7 +28670,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/weapons_strongbox" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/weapons_strongbox" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/weapons_strongbox" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28688,7 +28688,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/weightless_walker_module" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/weightless_walker_module" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/weightless_walker_module" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28706,7 +28706,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/windmill" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/windmill" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/windmill" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28724,7 +28724,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/winged_helmet" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/winged_helmet" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/winged_helmet" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28742,7 +28742,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wingsuit" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wingsuit" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wingsuit" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28760,7 +28760,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wood" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wood" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wood" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28778,7 +28778,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wood_log" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wood_log" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wood_log" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28796,7 +28796,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wood_shaft" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wood_shaft" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wood_shaft" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28814,7 +28814,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wood:_heavy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wood:_heavy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wood:_heavy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28832,7 +28832,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wood:_light" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wood:_light" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wood:_light" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28850,7 +28850,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wood:_medium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wood:_medium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wood:_medium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28868,7 +28868,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wooden_club" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wooden_club" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wooden_club" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28886,7 +28886,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wooden_dart" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wooden_dart" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wooden_dart" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28904,7 +28904,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wooden_gear" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wooden_gear" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wooden_gear" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28922,7 +28922,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wooden_rod" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wooden_rod" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wooden_rod" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28940,7 +28940,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wooden_slab" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wooden_slab" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wooden_slab" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28958,7 +28958,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wooden_walls" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wooden_walls" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wooden_walls" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28976,7 +28976,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wooden_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wooden_walls_schematic" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wooden_walls_schematic" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -28994,7 +28994,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/woodworking_station" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/woodworking_station" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/woodworking_station" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29012,7 +29012,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/worm_attractor" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/worm_attractor" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/worm_attractor" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29030,7 +29030,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/worm_egg" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/worm_egg" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/worm_egg" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29048,7 +29048,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/worm_fang" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/worm_fang" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/worm_fang" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29066,7 +29066,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/worm_oil" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/worm_oil" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/worm_oil" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29084,7 +29084,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/worm_sand" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/worm_sand" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/worm_sand" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29102,7 +29102,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/worm_scale" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/worm_scale" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/worm_scale" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29120,7 +29120,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/worm_silk" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/worm_silk" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/worm_silk" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29138,7 +29138,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/worm_tincture" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/worm_tincture" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/worm_tincture" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29156,7 +29156,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/worm_vivarium" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/worm_vivarium" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/worm_vivarium" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29174,7 +29174,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/worshipping_wreath" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/worshipping_wreath" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/worshipping_wreath" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29192,7 +29192,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wrapped_keffiyeh_scarf" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wrapped_keffiyeh_scarf" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wrapped_keffiyeh_scarf" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29210,7 +29210,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wreath" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wreath" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wreath" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29228,7 +29228,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wyndan_battle_axe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wyndan_battle_axe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wyndan_battle_axe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29246,7 +29246,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wyndan_flame_sword" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wyndan_flame_sword" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wyndan_flame_sword" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29264,7 +29264,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wyndan_hammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wyndan_hammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wyndan_hammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29282,7 +29282,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wyndan_hand_axe" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wyndan_hand_axe" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wyndan_hand_axe" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29300,7 +29300,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wyndan_sabre" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wyndan_sabre" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wyndan_sabre" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29318,7 +29318,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wyndan_warhammer" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wyndan_warhammer" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wyndan_warhammer" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29336,7 +29336,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/wyndanblade_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/wyndanblade_quarterstaff" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/wyndanblade_quarterstaff" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -29354,7 +29354,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item/zirconium_metal" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item/zirconium_metal" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item/zirconium_metal" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/public/sitemap-static.xml
+++ b/public/sitemap-static.xml
@@ -14,7 +14,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -32,7 +32,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/auctions" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/auctions" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/auctions" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -50,7 +50,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/clan/walkers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/clan/walkers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/clan/walkers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -68,7 +68,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/clanlist" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/clanlist" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/clanlist" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -86,7 +86,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/crafter" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/crafter" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/crafter" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -104,7 +104,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/creature" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/creature" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/creature" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -122,7 +122,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/diplomacy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/diplomacy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/diplomacy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -140,7 +140,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/item" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/item" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/item" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -158,7 +158,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/map" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/map" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/map" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -176,7 +176,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/maps" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/maps" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/maps" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -194,7 +194,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/members" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/members" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/members" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -212,7 +212,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/others" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/others" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/others" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -230,7 +230,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/perks" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/perks" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/perks" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -248,7 +248,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/privacy" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/privacy" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/privacy" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -266,7 +266,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/profile" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/profile" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/profile" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -284,7 +284,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/tech" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/tech" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/tech" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -302,7 +302,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/tech/Construction" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/tech/Construction" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/tech/Construction" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -320,7 +320,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/tech/Crafting" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/tech/Crafting" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/tech/Crafting" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -338,7 +338,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/tech/Equipment" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/tech/Equipment" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/tech/Equipment" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -356,7 +356,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/tech/Vitamins" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/tech/Vitamins" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/tech/Vitamins" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -374,7 +374,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/tech/Walkers" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/tech/Walkers" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/tech/Walkers" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -392,7 +392,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/trades" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/trades" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/trades" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -410,7 +410,7 @@
     <xhtml:link rel="alternate" hreflang="zh" href="https://stiletto.deeme.dev/zh/wiki" />
     <xhtml:link rel="alternate" hreflang="pt" href="https://stiletto.deeme.dev/pt/wiki" />
     <xhtml:link rel="alternate" hreflang="uk" href="https://stiletto.deeme.dev/uk/wiki" />
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,14 +2,14 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap>
     <loc>https://stiletto.deeme.dev/sitemap-static.xml</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
   </sitemap>
   <sitemap>
     <loc>https://stiletto.deeme.dev/sitemap-items.xml</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
   </sitemap>
   <sitemap>
     <loc>https://stiletto.deeme.dev/sitemap-creatures.xml</loc>
-    <lastmod>2026-07-16</lastmod>
+    <lastmod>2026-07-17</lastmod>
   </sitemap>
 </sitemapindex>

--- a/src/components/Wiki/SearchBar.tsx
+++ b/src/components/Wiki/SearchBar.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 type SearchBarProps = {
@@ -15,23 +16,54 @@ const SearchBar = ({
   onSearchClick,
 }: SearchBarProps) => {
   const { t } = useTranslation();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "/") {
+        const active = document.activeElement;
+        const isEditing =
+          active &&
+          (active.tagName === "INPUT" ||
+            active.tagName === "TEXTAREA" ||
+            active.tagName === "SELECT" ||
+            active.getAttribute("contenteditable") === "true");
+
+        if (!isEditing) {
+          e.preventDefault();
+          inputRef.current?.focus();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
 
   return (
     <div className="max-w-2xl mx-auto">
       <div
-        className="flex"
+        className="flex relative items-center"
         itemProp="potentialAction"
         data-testid="wiki-search"
       >
-        <input
-          type="search"
-          className="flex-1 px-4 py-3 bg-gray-700 border border-gray-600 rounded-l-lg text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          placeholder={t("common.search")}
-          aria-label={t("common.search")}
-          onChange={onSearchTextChange}
-          onKeyDown={onKeyPress}
-          value={searchText}
-        />
+        <div className="relative flex-1">
+          <input
+            ref={inputRef}
+            type="search"
+            className="w-full pl-4 pr-12 py-3 bg-gray-700 border border-gray-600 rounded-l-lg text-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder={t("common.search")}
+            aria-label={t("common.search")}
+            onChange={onSearchTextChange}
+            onKeyDown={onKeyPress}
+            value={searchText}
+          />
+          <kbd className="absolute right-3 top-1/2 -translate-y-1/2 px-2 py-0.5 text-xs text-gray-400 bg-gray-800 border border-gray-600 rounded pointer-events-none select-none">
+            /
+          </kbd>
+        </div>
         <button
           type="button"
           className="px-6 py-3 bg-blue-600 text-white rounded-r-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors duration-200"


### PR DESCRIPTION
Introduces a keyboard shortcut focusing search bar on keydown `/` on the Wiki page, with a subtle keys badge cue in the UI.

---
*PR created automatically by Jules for task [8249812977833925943](https://jules.google.com/task/8249812977833925943) started by @dm94*

## Summary by Sourcery

Add a keyboard shortcut and visual cue to quickly focus the Wiki search input.

New Features:
- Enable focusing the Wiki search input via the `/` keyboard shortcut on the Wiki page.
- Display an inline keyboard hint badge inside the Wiki search field indicating the `/` shortcut.

Documentation:
- Document the keyboard shortcut behavior and rationale in the Jules palette notes for Wiki search navigation.

Chores:
- Add a development log file capturing local dev server output.