### PR TITLE
⚡ Bolt: Optimize skill tree computations with linear complexity

### DIFF
--- a/src/components/TechTree/ModernSkillTree.tsx
+++ b/src/components/TechTree/ModernSkillTree.tsx
@@ -111,9 +111,36 @@ const ModernSkillTree: React.FC<ModernSkillTreeProps> = ({
     // Maintain a map of processed nodes to perform O(1) parentNode lookups rather than O(N) scans.
     const processedNodesMap = new Map<string, NodeData>();
 
+    // Flatten the tree for easier processing using O(N) linear recursion (avoiding array spreading overhead)
+    const flattenTree = (
+      nodesList: NodeData[],
+      acc: NodeData[] = [],
+    ): NodeData[] => {
+      for (const node of nodesList) {
+        acc.push(node);
+        flattenTree(node.children, acc);
+      }
+      return acc;
+    };
+
+    const flatNodes = flattenTree(treeData);
+
+    // Group nodes by their level to enable O(1) map lookup during layout processing,
+    // avoiding the O(N^2) complexity of scanning flatNodes for each level.
+    const nodesByLevel = new Map<number, NodeData[]>();
+    for (let i = 0; i < flatNodes.length; i++) {
+      const node = flatNodes[i];
+      let levelList = nodesByLevel.get(node.level);
+      if (!levelList) {
+        levelList = [];
+        nodesByLevel.set(node.level, levelList);
+      }
+      levelList.push(node);
+    }
+
     // Process nodes level by level for horizontal layout
-    const processLevel = (nodes: NodeData[], level: number, startY: number) => {
-      const levelNodes = nodes.filter((node) => node.level === level);
+    const processLevel = (level: number, startY: number) => {
+      const levelNodes = nodesByLevel.get(level) || [];
       if (levelNodes.length === 0) {
         return;
       }
@@ -122,7 +149,8 @@ const ModernSkillTree: React.FC<ModernSkillTreeProps> = ({
       const totalHeight = (levelNodes.length - 1) * verticalSpacing;
       let currentY = startY - totalHeight / 2;
 
-      for (const node of levelNodes) {
+      for (let i = 0; i < levelNodes.length; i++) {
+        const node = levelNodes[i];
         // Set horizontal position based on level
         const x = 100 + level * horizontalSpacing;
         const y = currentY;
@@ -151,26 +179,12 @@ const ModernSkillTree: React.FC<ModernSkillTreeProps> = ({
         currentY += verticalSpacing;
       }
 
-      // Process next level
-      processLevel(nodes, level + 1, startY);
+      // Process next level using O(1) level lookup
+      processLevel(level + 1, startY);
     };
-
-    // Flatten the tree for easier processing using O(N) linear recursion (avoiding array spreading overhead)
-    const flattenTree = (
-      nodesList: NodeData[],
-      acc: NodeData[] = [],
-    ): NodeData[] => {
-      for (const node of nodesList) {
-        acc.push(node);
-        flattenTree(node.children, acc);
-      }
-      return acc;
-    };
-
-    const flatNodes = flattenTree(treeData);
 
     // Start processing from level 0
-    processLevel(flatNodes, 0, 300);
+    processLevel(0, 300);
 
     return { nodes: processedNodes, edges: processedEdges };
   }, []);
@@ -362,14 +376,39 @@ const ModernSkillTree: React.FC<ModernSkillTreeProps> = ({
       return { width: 1000, height: 600, offsetX: 0, offsetY: 0 };
     }
 
-    const minX = Math.min(...nodes.map((n) => n.x));
-    const minY = Math.min(...nodes.map((n) => n.y));
-    const maxX = Math.max(...nodes.map((n) => n.x)) + 100;
-    const maxY = Math.max(...nodes.map((n) => n.y)) + 100;
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      if (node.x < minX) {
+        minX = node.x;
+      }
+      if (node.y < minY) {
+        minY = node.y;
+      }
+      if (node.x > maxX) {
+        maxX = node.x;
+      }
+      if (node.y > maxY) {
+        maxY = node.y;
+      }
+    }
+
+    const maxXWithPadding = maxX + 100;
+    const maxYWithPadding = maxY + 100;
+
     // Offset to ensure all nodes are visible (no negative positions)
     const offsetX = minX < 0 ? -minX + 20 : 0;
     const offsetY = minY < 0 ? -minY + 20 : 0;
-    return { width: maxX + offsetX, height: maxY + offsetY, offsetX, offsetY };
+    return {
+      width: maxXWithPadding + offsetX,
+      height: maxYWithPadding + offsetY,
+      offsetX,
+      offsetY,
+    };
   }, [nodes]);
 
   return (


### PR DESCRIPTION
This change optimizes performance when rendering the interactive skill/tech tree.

1. **Layout Calculation (`calculateNodePositions`)**:
   - Previously, at each tree level `L`, `flatNodes` was filtered via `.filter((node) => node.level === level)`. In larger or deeply nested trees, this results in quadratic time complexity $O(L \times N)$, or $O(N^2)$ in skewed cases.
   - We pre-group `flatNodes` by their `level` using a single-pass $O(N)$ loop to populate an `nodesByLevel` map. The recursive `processLevel` then accesses the level nodes in $O(1)$ lookup time, achieving a true $O(N)$ linear complexity.

2. **Dimensions and Bounds Calculation (`containerDimensions`)**:
   - Previously, calculating the min/max coordinates of the tree performed four separate mapping passes (`nodes.map(...)`) and four spread arguments (`Math.min(...nodes.map(...))`). This causes performance and memory churn, and risks stack overflow on very large trees due to the spread syntax limit.
   - We optimized this to use a single-pass linear scan (`for` loop), which computes all four min/max boundaries in exactly one iteration, allocating zero intermediate arrays.

---
*PR created automatically by Jules for task [15483495898023706487](https://jules.google.com/task/15483495898023706487) started by @dm94*

## Summary by Sourcery

Optimize ModernSkillTree layout and container sizing computations for linear-time performance on large trees.

Enhancements:
- Precompute a flat node list and group nodes by level to enable efficient level-based layout processing without repeated scans.
- Streamline level iteration and node positioning using index-based loops for improved performance.
- Replace multiple map/spread passes in containerDimensions with a single linear scan to compute min/max bounds and apply padding.